### PR TITLE
Convert link-checker into a python linter

### DIFF
--- a/.trunk/link-checker/checker.py
+++ b/.trunk/link-checker/checker.py
@@ -103,4 +103,4 @@ with open(path, "r") as file:
                 print("{}:{}: {} ({})".format(filename, line_num, message, result.name))
 
 if fail:
-    exit(1)
+    exit(2)

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -36,7 +36,7 @@ lint:
           parse_regex: "(?P<path>.*?):(?P<line>\\d+): (?P<message>.*) \\((?P<code>\\w+)\\)"
           run: python3 ${workspace}/.trunk/link-checker/checker.py ${target}
           batch: false
-          success_codes: [0, 1]
+          success_codes: [0, 2]
       suggest_if: never
 runtimes:
   enabled:


### PR DESCRIPTION
Super speedy, runs on `-a` in 3-4 seconds

<img width="1021" alt="Screenshot 2023-08-09 at 3 29 55 PM" src="https://github.com/trunk-io/docs/assets/42743566/4972d673-003a-41e5-8c13-f641f5535fff">

Note that there's no notion of redirects in this setup (there doesn't need to be at the moment)