### PR TITLE
Update severity/threshold section and add nocheck section

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -6,3 +6,4 @@
 plugins
 user_trunk.yaml
 user.yaml
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,16 +1,16 @@
 version: 0.1
 
 cli:
-  version: 1.18.0
+  version: 1.22.0
 
 plugins:
   sources:
     - id: trunk
-      ref: v1.3.0
+      ref: v1.5.0
       uri: https://github.com/trunk-io/plugins
     - id: configs
       uri: https://github.com/trunk-io/configs
-      ref: v0.0.10
+      ref: v1.0.4
 
 lint:
   # See inherited enabled linters and other config here:

--- a/check/configuration/README.md
+++ b/check/configuration/README.md
@@ -168,7 +168,7 @@ For full details please see the [Ignoring Issues and Files](ignoring-issues.md) 
 
 ### Blocking Thresholds
 
-All issue severities are considered blocking by default. In cases where you might want to slowly try out a new linter, we provide a mechanism to set specific thresholds for each linter.
+All issue severities low-high are considered blocking by default. In cases where you might want to slowly try out a new linter, we provide a mechanism to set specific thresholds for each linter.
 
 ```yaml
 lint:
@@ -179,7 +179,7 @@ lint:
 
 Every entry in `threshold` defines a set of linters and the severity threshold that is considered blocking. In this example, we're saying that only `high` lint issues should be considered blocking for `clang-tidy`.
 
-<table><thead><tr><th width="97">Key</th><th>Value</th></tr></thead><tbody><tr><td>linters</td><td>List of linters (e.g. <code>[black, eslint]</code>) or the special <code>[ALL]</code> tag</td></tr><tr><td>level</td><td>Threshold at which issues are considered blocking. One of : <code>note</code>, <code>low</code>, <code>medium</code>, <code>high</code>, or <code>none</code> (this last option will result in issues never blocking)</td></tr></tbody></table>
+<table><thead><tr><th width="97">Key</th><th>Value</th></tr></thead><tbody><tr><td>linters</td><td>List of linters (e.g. <code>[black, eslint]</code>) or the special <code>[ALL]</code> tag</td></tr><tr><td>level</td><td>Default <code>low</code>. Threshold at which issues are considered blocking. One of: <code>note</code>, <code>low</code>, <code>medium</code>, <code>high</code>, or <code>none</code> (this last option will result in issues never blocking)</td></tr></tbody></table>
 
 ### Trigger rules
 

--- a/check/configuration/custom-linters/commands/output-types.md
+++ b/check/configuration/custom-linters/commands/output-types.md
@@ -140,7 +140,7 @@ If your linter produces a different output type, you can also write a [parser](c
 * `path`: file path (required)
 * `line`: line number
 * `col`: column number
-* `severity`: one of `allow`, `deny`, `disabled`, `error`, `info`, `warning`
+* `severity`: one of `note`, `notice`, `allow`, `deny`, `disabled`, `error`, `info`, `warning`
 * `code`: linter diagnostic code
 * `message`: description
 

--- a/check/configuration/custom-linters/lint-config.md
+++ b/check/configuration/custom-linters/lint-config.md
@@ -115,7 +115,7 @@ lint:
 
 ### `threshold`
 
-`threshold`: where you specify the blocking behavior of linters. The threshold for whether an error from a linter should block commits or not.
+`threshold`: where you specify the blocking behavior of linters. The [threshold](../README.md#blocking-thresholds) for whether an error from a linter should block commits or not.
 
 ### `upstream_mode`
 

--- a/check/configuration/ignoring-issues.md
+++ b/check/configuration/ignoring-issues.md
@@ -4,6 +4,8 @@ description: >-
   files.
 ---
 
+<!-- trunk-ignore-all(trunk): These ignores are for docs -->
+
 # Ignoring Issues and Files
 
 ## Ignoring parts of a file

--- a/check/configuration/ignoring-issues.md
+++ b/check/configuration/ignoring-issues.md
@@ -58,7 +58,13 @@ struct FooBar {
 };
 ```
 
-Notice that a `trunk-ignore` directive applies not to the next line, but the next non-`trunk-ignore` line (this only works for _preceding_ directives, not _trailing_ directives), and that you can use a single directive for suppressing multiple checks.
+`trunk-ignore` directives can also apply to other `trunk-ignore`s if need be:
+
+```ts
+// trunk-ignore(eslint/max-line-length)
+// trunk-ignore(eslint/@typescript-eslint/no-unsafe-member-access,eslint/@typescript-eslint/no-unsafe-assignment)
+const version = parsedConfig.version;
+```
 
 ### Ignoring all issues/formatting in a file
 
@@ -87,6 +93,24 @@ struct FooBar {
   void *ptr2 = NULL;
   // trunk-ignore-end(clang-tidy)
 };
+```
+
+### Tracking unused ignores
+
+Trunk will alert you if your `trunk-ignore` directives are unused. This can happen due to user error or even innocuously over time, for example, if your internal APIs change or if a linter's output changes.
+
+```
+app/parse.ts:18:3
+ 18:3  note  trunk-ignore(eslint/@typescript-eslint/no-unsafe-member-access)   trunk/ignore-does-nothing
+             is not suppressing a lint issue
+```
+
+[Hold the Line](./hold-the-line.md) will continue to only surface ignore issues that you have introduced, and these issues will have a `note` [severity](./README.md#blocking-thresholds), indicating they are non-blocking by default.
+
+If you need to, you can ignore issues from unused `trunk-ignore` directives, using `trunk-ignore(trunk)`:
+```
+// trunk-ignore(trunk): This error will resurface after our API migration.
+// trunk-ignore(eslint/@typescript-eslint/no-unsafe-member-access)
 ```
 
 ### Specification


### PR DESCRIPTION
- Update information to the severity/threshold section to note that we also support the `note` level (and update output types accordingly). 
- Document that we surface info on unused diagnostics, and that these can be ignored with `trunk-ignore(trunk)`
- Run `trunk upgrade`

Note: this requires `1.22.1` or later with the [`note` severity level and the nocheck fixes](https://github.com/trunk-io/trunk/pull/13771).