### PR TITLE
Collection of minifixes for code-quality/setup pages

### DIFF
--- a/code-quality/ci-setup/get-started.md
+++ b/code-quality/ci-setup/get-started.md
@@ -83,7 +83,7 @@ If this continues to fail, then run `git checkout refs/pull/<PR number>/merge &&
 
 You can include `/trunk skip-check` in the body of a PR description (i.e. the first comment on a given PR) to mark Trunk Code Quality as "skipped". Trunk Code Quality will still run on your PR and report issues, but this will allow the PR to pass a GitHub required status check on `Trunk Check`.
 
-This can be helpful if Code Quality is flagging known issues in a given PR which you don't want to [ignore](../linters/ignoring-issues-and-files.md), which if you're doing a large refactor, can come in very handy.
+This can be helpful if Code Quality is flagging known issues in a given PR that you don't want to [ignore](../linters/ignoring-issues-and-files.md), which can come in handy if you're doing a large refactor.
 
 </details>
 

--- a/code-quality/ci-setup/github-integration.md
+++ b/code-quality/ci-setup/github-integration.md
@@ -65,7 +65,7 @@ If this continues to fail, then run `git checkout refs/pull/<PR number>/merge &&
 
 You can include `/trunk skip-check` in the body of a PR description (i.e. the first comment on a given PR) to mark Trunk Code Quality as "skipped". Trunk Code Quality will still run on your PR and report issues, but this will allow the PR to pass a GitHub required status check on `Trunk Check`.
 
-This can be helpful if Code Quality is flagging known issues in a given PR which you don't want to ignore, which if you're doing a large refactor, can come in very handy.
+This can be helpful if Code Quality is flagging known issues in a given PR that you don't want to ignore, which can come in handy if you're doing a large refactor.
 
 </details>
 

--- a/code-quality/overview/README.md
+++ b/code-quality/overview/README.md
@@ -14,7 +14,7 @@ There are many reasons for you to want to use a metalinter like Trunk Code Quali
 
 Trunk Code Quality is easy to adopt. [Running `trunk init`](../setup-and-installation/initialize-trunk.md) will [recommend linters and formatters](../linters/supported/) for your project with reasonable default configuration. Hold off on fixing existing issues using [hold-the-line](how-does-it-work.md#hold-the-line) and only get warnings for new issues introduced in each commit or PR.
 
-Trunk Code Quality [GitHub Integration](../ci-setup/github-integration.md)s to set up nightly runs and linter checks on PRs.&#x20;
+Trunk Code Quality [GitHub Integrations](../ci-setup/github-integration.md) to set up nightly runs and linter checks on PRs.&#x20;
 
 #### Run and manage a long list of linters
 
@@ -24,7 +24,7 @@ Trunk will install, manage, and run tools like linters and formatters for you. T
 
 [Adopting new linters is a pain](https://trunk.io/blog/reasons-developers-hate-linters) because of the large amount of upfront configuration and fixes needed. Enabling a new linter or formatter in an old repo will yield thousands of issues, most of which might not have auto fixes.
 
-Trunk supports [hold-the-line](how-does-it-work.md#hold-the-line) to lint only new issues introduced with a commit or PR, to let developers adopt new linters fast, focus on preventing new issues first, and[ report on existing issues nightly](../ci-setup/) to fix later. Waiting will only accumulate debt, stop debt accumulation immediately and fix as you code.
+Trunk supports [hold-the-line](how-does-it-work.md#hold-the-line) to lint only new issues introduced with a commit or PR, to let developers adopt new linters fast, focus on preventing new issues first, and[ report on existing issues nightly](../ci-setup/) to fix later. Waiting will only accumulate debt; stop debt accumulation immediately and fix as you code.
 
 #### Linters take too long to run
 
@@ -62,7 +62,7 @@ Trunk Code Quality speeds up static analysis by using a background daemon to che
 
 #### **Time-consuming PR iteration and triage**
 
-Trunk Code Quality speeds up PR iteration by showing the _same_ results locally and [on CI](../ci-setup/), improving PR triage. It can optionally also function as a [githooks manager](../../cli/getting-started/actions/git-hooks.md) to reject `git push`es unless they're passing `trunk check`
+Trunk Code Quality speeds up PR iteration by showing the _same_ results locally and [on CI](../ci-setup/), improving PR triage. It can optionally also function as a [githooks manager](../../cli/getting-started/actions/git-hooks.md) to reject `git push`es unless they're passing `trunk check`.
 
 #### **Lack of team visibility into the repo's health**
 

--- a/code-quality/overview/README.md
+++ b/code-quality/overview/README.md
@@ -14,7 +14,7 @@ There are many reasons for you to want to use a metalinter like Trunk Code Quali
 
 Trunk Code Quality is easy to adopt. [Running `trunk init`](../setup-and-installation/initialize-trunk.md) will [recommend linters and formatters](../linters/supported/) for your project with reasonable default configuration. Hold off on fixing existing issues using [hold-the-line](how-does-it-work.md#hold-the-line) and only get warnings for new issues introduced in each commit or PR.
 
-Trunk Code Quality [GitHub Integrations](../ci-setup/github-integration.md) to set up nightly runs and linter checks on PRs.&#x20;
+Use Trunk Code Quality [GitHub Integrations](../ci-setup/github-integration.md) to set up nightly runs and linter checks on PRs.&#x20;
 
 #### Run and manage a long list of linters
 

--- a/code-quality/overview/how-does-it-work.md
+++ b/code-quality/overview/how-does-it-work.md
@@ -38,7 +38,7 @@ Some native linters are more compute/memory intensive and `check` support disabl
 
 Trunk hermetically installs the static analysis tools you run and the runtimes they run on. This means, these tools are installed and managed by the Trunk CLI, unaffected by your systems environment.
 
-If a tool is required `python 3.10` but you require `python 3.7` for certain projects you're working on, Trunk will manage that tool and it's `python 3.10` runtime automatically and not affect the `python 3.7` environment. This means Trunk will not affect or pollute your machine.
+If a tool requires `python 3.10` but the projects you're working on you require `python 3.7`, Trunk will manage that tool and it's `python 3.10` runtime automatically and not affect the `python 3.7` environment. This means Trunk will not affect or pollute your machine.
 
 Trunk manages the hermetic installation of all required runtimes. You can also specifically pin a version of a runtime you'd like Trunk to use, or tell Trunk to re-use an already-installed runtime on the system.
 

--- a/code-quality/overview/how-does-it-work.md
+++ b/code-quality/overview/how-does-it-work.md
@@ -38,7 +38,7 @@ Some native linters are more compute/memory intensive and `check` support disabl
 
 Trunk hermetically installs the static analysis tools you run and the runtimes they run on. This means, these tools are installed and managed by the Trunk CLI, unaffected by your systems environment.
 
-If a tool requires `python 3.10` but the projects you're working on you require `python 3.7`, Trunk will manage that tool and it's `python 3.10` runtime automatically and not affect the `python 3.7` environment. This means Trunk will not affect or pollute your machine.
+If a tool requires `python 3.10` but the projects you're working on requires `python 3.7`, Trunk will manage that tool and it's `python 3.10` runtime automatically and not affect the `python 3.7` environment. This means Trunk will not modify or pollute your machine.
 
 Trunk manages the hermetic installation of all required runtimes. You can also specifically pin a version of a runtime you'd like Trunk to use, or tell Trunk to re-use an already-installed runtime on the system.
 

--- a/code-quality/overview/why-code-quality.md
+++ b/code-quality/overview/why-code-quality.md
@@ -14,7 +14,7 @@ Now factor in your IaC files, CI config, and build scripts; these are the places
 
 Having good linter coverage in any modern project is difficult because there isn't just one language and technology. There are tons of scripts, images, config files, docs, and IaC files to lint.&#x20;
 
-The tools required to lint everything installs, runs, outputs, upgrades, and configures differently. Now consider the tools that require dependencies and runtimes, such as [nancy](../linters/supported/nancy.md) and [actionlint](../linters/supported/actionlint.md) that depends on Go, or [Bandit](../linters/supported/bandit.md) and [sqlfmt](../linters/supported/sqlfmt.md) that depend on Python. You have to maintain **version pinned tools** and their **runtimes**.
+The tools required to lint everything install, run, output, upgrade, and configure differently. Now consider the tools that require dependencies and runtimes, such as [nancy](../linters/supported/nancy.md) and [actionlint](../linters/supported/actionlint.md) that depend on Go, or [Bandit](../linters/supported/bandit.md) and [sqlfmt](../linters/supported/sqlfmt.md) that depend on Python. You have to maintain **version pinned tools** and their **runtimes**.
 
 These tools are also prone to tool-rot, where dependencies become old, deprecated, or known vulnerabilities are discovered. In fact, [82% of open-source projects suffer from tool-rot](https://trunk.io/blog/82-of-open-source-projects-suffer-from-tool-rot). Keeping these tools up to date is a Sisyphean task. It's better to have a metalinter handle all of it.
 
@@ -26,7 +26,7 @@ Trunk Code Quality solves this by being [Git aware](how-does-it-work.md#hold-the
 
 ### **Why not just write a script?**&#x20;
 
-[ESLint](https://github.com/eslint/eslint) adopted Trunk Code Quality to replace their [linter script](https://github.com/eslint/eslint/pull/18643/files#diff-3fc6364bd19a0e4ee8d1e0fe312541201418d80f9d1b08015db4d11e7dbde39e) because it's difficult to maintain. Writing a script that can do everything a metalinter does is not trivial. You need to handle per-line and file properly ignores, adapt to the many config and output formats of different tools, support different OS and architectures, lint in a way that's [git-aware](how-does-it-work.md#hold-the-line) so it can run on large code bases quickly, and adapt to breaking changes or newly added linters.
+[ESLint](https://github.com/eslint/eslint) adopted Trunk Code Quality to replace their [linter script](https://github.com/eslint/eslint/pull/18643/files#diff-3fc6364bd19a0e4ee8d1e0fe312541201418d80f9d1b08015db4d11e7dbde39e) because it's difficult to maintain. Writing a script that can do everything a metalinter does is not trivial. You need to handle per-line and file ignores properly, adapt to the many config and output formats of different tools, support different OS and architectures, lint in a way that's [git-aware](how-does-it-work.md#hold-the-line) so it can run on large code bases quickly, and adapt to breaking changes or newly added linters.
 
 That code is outside of a project's core goals and is bound to become debt. Code Quality is free to run locally and in CI, and reporting to the [Web App](../ci-setup/github-integration.md) is free for open-source teams.&#x20;
 

--- a/code-quality/setup-and-installation/deal-with-existing-issues.md
+++ b/code-quality/setup-and-installation/deal-with-existing-issues.md
@@ -1,6 +1,6 @@
 # Deal with Existing Issues
 
-After initializing Trunk, you can begin to scan for issues in your repo. You can decide to fix them up front, fix them incrementally as you code, or ignore irrelevant suggestions. This page walks through the process of fixing existing issues.
+After initializing Trunk, you can begin scanning for issues in your repo, and decide whether to fix them up front, fix them incrementally as you code, or ignore irrelevant suggestions. This page walks through the process of fixing existing issues.
 
 If you **only want to prevent new issues** from new code changes, skip to [prevent-new-issues.md](prevent-new-issues.md "mention").
 
@@ -71,9 +71,9 @@ trunk check disable <linter>
 
 #### Ignore Issues
 
-If there are warnings that don't apply to your project, you can ignore them by line, by file, and ignore a class of warnings in each linter's config files.
+If there are warnings that don't apply to your project, you can ignore them by line, by file, and by entire class of warnings in each linter's config files.
 
-To tell Trunk Code Quality to ignore a line in your source code with a special comment like this:
+You can tell Trunk Code Quality to ignore a line in your source code with a special comment like this:
 
 ```cpp
 struct FooBar {
@@ -95,7 +95,7 @@ lint:
         - src/generated/**
 ```
 
-You can also ignore an entire class of warnings, you can do this in the config file of your linter, either at the project root or in `.trunk/configs`
+You can also ignore an entire class of warnings using the config file of your linter, either at the project root or in `.trunk/configs`
 
 For example, these are the ignores for Markdownlint in `.trunk/configs/.markdownlint.yaml`:
 

--- a/code-quality/setup-and-installation/deal-with-existing-issues.md
+++ b/code-quality/setup-and-installation/deal-with-existing-issues.md
@@ -71,7 +71,7 @@ trunk check disable <linter>
 
 #### Ignore Issues
 
-If there are warnings that don't apply to your project, you can ignore them by line, by file, and by entire class of warnings in each linter's config files.
+If there are warnings that don't apply to your project, you can ignore them by line, by file, or by entire class of warnings in each linter's config files.
 
 You can tell Trunk Code Quality to ignore a line in your source code with a special comment like this:
 

--- a/code-quality/setup-and-installation/initialize-trunk.md
+++ b/code-quality/setup-and-installation/initialize-trunk.md
@@ -80,9 +80,9 @@ When the launcher is called for the first time by your teammates, the Trunk Laun
 
 <details>
 
-<summary>Using homebrew</summary>
+<summary>macOS (using homebrew)</summary>
 
-You can run the following command if you prefer to install this tool via homebrew. Keep in mind that other developers on your team will also have to install manually.
+You can run the following command if you prefer to install this tool via [homebrew](https://brew.sh/). Keep in mind that other developers on your team will also have to install manually.
 
 ```bash
 brew install trunk-io
@@ -214,4 +214,4 @@ If you're using an IDE Extension like `clangd` with an LSP that relies on those 
 
 ### Next Steps
 
-After initializing Trunk Code Quality, you can check for issues and configure Code Quality. The next steps in Setup & Installation will walk you through this process.
+After initializing Trunk Code Quality, you can check for issues and configure Code Quality. The [next steps](./deal-with-existing-issues.md) in Setup & Installation will walk you through this process.

--- a/code-quality/setup-and-installation/prevent-new-issues.md
+++ b/code-quality/setup-and-installation/prevent-new-issues.md
@@ -15,14 +15,14 @@ repo:
 
 ### Prevent Issues On Commits
 
-Code Quality can automatically run formatters on each commit to new formatting from appearing in your commit history. Code Quality uses a Git hook to automate this process. Formatting changes will automatically be applied to what you commit.
+Code Quality can automatically run formatters on each commit to prevent new formatting from appearing in your commit history. Code Quality uses a Git hook to automate this process. Formatting changes will automatically be applied to what you commit.
 
 <pre class="language-shell"><code class="lang-shell"><strong>trunk actions enable trunk-fmt-pre-commit
 </strong></code></pre>
 
 ### Prevent Issues Before Push
 
-Code Quality can automatically run linters and formatters on each commit to new formatting from appearing in your commit history. Code Quality uses a Git hook to automate this process. This will flag lint issues so they never make it into your PRs.
+Code Quality can automatically run linters and formatters on each commit to prevent new formatting from appearing in your commit history. Code Quality uses a Git hook to automate this process. This will flag lint issues so they never make it into your PRs.
 
 ```bash
 trunk actions enable trunk-check-pre-push


### PR DESCRIPTION
Small typo fixes, missing words, better grammar, missing links, etc. Fell free to tweak, revert, add onto, cherry-pick, etc. any of these changes.

Changed pages:
* https://docs.trunk.io/code-quality/overview
* https://docs.trunk.io/code-quality/overview/how-does-it-work
* https://docs.trunk.io/code-quality/overview/why-code-quality
* https://docs.trunk.io/code-quality/setup-and-installation/github-integration
* https://docs.trunk.io/code-quality/setup-and-installation/initialize-trunk
* https://docs.trunk.io/code-quality/setup-and-installation/deal-with-existing-issues
* https://docs.trunk.io/code-quality/setup-and-installation/prevent-new-issues

Manually reviewed the generated `revision` and they look ok.