### PR TITLE
[TRUNK-12833] Add package.json for submodule import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@trunkio/docs",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module"
+}


### PR DESCRIPTION
As part of https://github.com/trunk-io/trunk/pull/17733, we're importing the trunk docs into the main repo as a submodule. This requires us to add a package.json to this repo, so we can import markdown files from it and into the web app.
