### PR TITLE
docs(flaky-tests): rename Threshold Monitor to Failure Rate Monitor

### DIFF
--- a/flaky-tests/detection/README.md
+++ b/flaky-tests/detection/README.md
@@ -12,8 +12,8 @@ Each monitor independently observes your test runs and tracks two states per tes
 
 | Priority | Status | Condition |
 |----------|--------|-----------|
-| Highest | **Broken** | Any enabled broken-type threshold monitor is active for this test |
-| Middle | **Flaky** | Any enabled flaky-type monitor (threshold or pass-on-retry) is active |
+| Highest | **Broken** | Any enabled broken-type failure rate monitor is active for this test |
+| Middle | **Flaky** | Any enabled flaky-type monitor (failure rate or pass-on-retry) is active |
 | Lowest | **Healthy** | No active monitors |
 
 If a test triggers both a broken monitor and a flaky monitor simultaneously, it shows as **Broken**. When the broken monitor resolves (e.g., you fix the regression and the failure rate drops), the test transitions to **Flaky** if a flaky monitor is still active, or to **Healthy** if no monitors remain active.
@@ -24,16 +24,16 @@ A test stays in its detected state until every relevant monitor that flagged it 
 
 When you disable or delete a monitor, it is immediately set to **resolved** for every test case in the repo. This triggers a status re-evaluation for all affected tests. If the disabled monitor was the only active monitor for a test, that test transitions to healthy. If other monitors are still active, the test remains in the most severe active state.
 
-For example, if you have a broken threshold monitor and a flaky pass-on-retry monitor, and you disable the broken monitor, any test that was only flagged by the broken monitor will become healthy. A test flagged by both will transition from broken to flaky (because pass-on-retry is still active).
+For example, if you have a broken failure rate monitor and a flaky pass-on-retry monitor, and you disable the broken monitor, any test that was only flagged by the broken monitor will become healthy. A test flagged by both will transition from broken to flaky (because pass-on-retry is still active).
 
 ## Monitor Types
 
 | Monitor | What it detects | Detection type | Plan availability | Default state |
 |---|---|---|---|---|
 | [**Pass-on-Retry**](pass-on-retry-monitor.md) | A test fails then passes on the same commit (retry after failure) | Flaky | Team and above | Enabled |
-| [**Threshold**](threshold-monitor.md) | Failure rate exceeds a configured percentage over a time window | Flaky or Broken | Paid plans | Disabled |
+| [**Failure Rate**](threshold-monitor.md) | Failure rate exceeds a configured percentage over a time window | Flaky or Broken | Paid plans | Disabled |
 
-You can run multiple monitors simultaneously. For example, you might use pass-on-retry to catch classic retry-based flakiness while also running threshold monitors scoped to different branches. A common pattern is to pair a broken-type threshold monitor (catching consistently failing tests) with a flaky-type threshold monitor (catching intermittently failing tests). See [Threshold Monitor: Recommended Configurations](threshold-monitor.md#recommended-configurations) for details.
+You can run multiple monitors simultaneously. For example, you might use pass-on-retry to catch classic retry-based flakiness while also running failure rate monitors scoped to different branches. A common pattern is to pair a broken-type failure rate monitor (catching consistently failing tests) with a flaky-type failure rate monitor (catching intermittently failing tests). See [Failure Rate Monitor: Recommended Configurations](threshold-monitor.md#recommended-configurations) for details.
 
 If you need to manually flag a test that automated monitors haven't caught, use [Flag as Flaky](flag-as-flaky.md) from the test detail page.
 
@@ -41,7 +41,7 @@ If you need to manually flag a test that automated monitors haven't caught, use 
 
 Tests often behave differently depending on where they run. Failures on `main` are usually unexpected and signal flakiness. Failures on PR branches may be expected during active development. Merge queue failures are suspicious because the code has already passed PR checks.
 
-Rather than applying a single set of branch rules automatically, Trunk gives you control over how detection treats different branches through **branch scoping** on threshold monitors. You can create separate monitors with different thresholds and windows for your stable branch, PR branches, and merge queue branches. See [Threshold Monitor: Recommended configurations](threshold-monitor.md#recommended-configurations) for specific guidance.
+Rather than applying a single set of branch rules automatically, Trunk gives you control over how detection treats different branches through **branch scoping** on failure rate monitors. You can create separate monitors with different thresholds and windows for your stable branch, PR branches, and merge queue branches. See [Failure Rate Monitor: Recommended configurations](threshold-monitor.md#recommended-configurations) for specific guidance.
 
 Pass-on-retry detection is branch-agnostic. It flags any test that fails and passes on the same commit, regardless of which branch the test ran on.
 

--- a/flaky-tests/detection/threshold-monitor.md
+++ b/flaky-tests/detection/threshold-monitor.md
@@ -2,15 +2,19 @@
 description: Detect flaky or broken tests based on failure rate over a configurable time window
 ---
 
-# Threshold Monitor
+# Failure Rate Monitor
 
-The threshold monitor detects tests based on failure rate over a rolling time window. Unlike pass-on-retry, which looks for a specific pattern on a single commit, the threshold monitor identifies tests that fail too often over a period of time, even if no individual failure looks like a retry.
+The failure rate monitor detects tests based on failure rate over a rolling time window. Unlike pass-on-retry, which looks for a specific pattern on a single commit, the failure rate monitor identifies tests that fail too often over a period of time, even if no individual failure looks like a retry.
 
-You can create multiple threshold monitors with different configurations. This is how you tailor detection to different branches, test volumes, sensitivity levels, and detection types.
+You can create multiple failure rate monitors with different configurations. This is how you tailor detection to different branches, test volumes, sensitivity levels, and detection types.
+
+{% hint style="info" %}
+This monitor was previously called the **Threshold Monitor**. The name changed to **Failure Rate Monitor** to more clearly describe what it measures. If you use webhooks or the GraphQL API, the `monitorType` field now surfaces as `failure_rate` instead of `threshold`. Both values are accepted as input during the transition period.
+{% endhint %}
 
 ## Detection Type
 
-Each threshold monitor has a **detection type** — either **flaky** or **broken** — which controls what status a test receives when the monitor flags it:
+Each failure rate monitor has a **detection type** — either **flaky** or **broken** — which controls what status a test receives when the monitor flags it:
 
 - **Flaky monitors** catch tests that fail intermittently (e.g., 20–50% failure rate). These are typically caused by timing issues, shared state, or non-deterministic behavior.
 - **Broken monitors** catch tests that fail consistently at a high rate (e.g., 80%+ failure rate). These usually indicate a real regression — something in the code or environment is genuinely broken and needs a fix.
@@ -175,7 +179,7 @@ Tests that are still running but haven't accumulated enough runs to meet the min
 
 ## Muting
 
-You can temporarily mute a threshold monitor for a specific test case. See [Muting monitors](README.md#muting-monitors) for details.
+You can temporarily mute a failure rate monitor for a specific test case. See [Muting monitors](README.md#muting-monitors) for details.
 
 ## Recommended Configurations
 

--- a/flaky-tests/get-started/README.md
+++ b/flaky-tests/get-started/README.md
@@ -43,12 +43,12 @@ After uploads are flowing, navigate to your repo → **Flaky Tests > Monitors** 
 
 **Pass-on-retry** is enabled by default and is the recommended baseline for everyone. It catches the most common flakiness pattern — a test that fails and then passes on retry within the same commit — without any configuration needed.
 
-**Threshold monitors** let you detect flakiness based on failure rate over a rolling time window. How you configure them depends on your CI setup:
+**Failure rate monitors** let you detect flakiness based on failure rate over a rolling time window. How you configure them depends on your CI setup:
 
-- **If tests must pass before merging to main**, set up a threshold monitor scoped to `main` to catch an elevated failure rate. For example, if you run tests 5 times per day on `main`, a 24-hour rolling window with a minimum of 4 runs and a failure threshold of 25% is a reasonable starting point. This ensures the monitor has enough data before flagging anything.
+- **If tests must pass before merging to main**, set up a failure rate monitor scoped to `main` to catch an elevated failure rate. For example, if you run tests 5 times per day on `main`, a 24-hour rolling window with a minimum of 4 runs and a failure threshold of 25% is a reasonable starting point. This ensures the monitor has enough data before flagging anything.
 - **If you use a merge queue**, consider a dedicated monitor scoped to your merge queue branches (e.g., `trunk-merge/*` or `gh-readonly-queue/*`). Failures here are especially suspicious since the code has already passed PR checks, so a low threshold is appropriate.
 
-[How threshold monitors work →](../detection/threshold-monitor.md)
+[How failure rate monitors work →](../detection/threshold-monitor.md)
 
 #### Quarantining
 

--- a/summary.md
+++ b/summary.md
@@ -97,7 +97,7 @@
 * [Dashboard](flaky-tests/dashboard.md)
 * [Flaky test detection](flaky-tests/detection/README.md)
   * [Pass-on-Retry Monitor](flaky-tests/detection/pass-on-retry-monitor.md)
-  * [Threshold Monitor](flaky-tests/detection/threshold-monitor.md)
+  * [Failure Rate Monitor](flaky-tests/detection/threshold-monitor.md)
   * [Flag as Flaky](flaky-tests/detection/flag-as-flaky.md)
 * [Infrastructure Failure Protection](flaky-tests/infrastructure-failure-protection.md)
 * [The Importance of PR Test Results](flaky-tests/the-importance-of-pr-test-results.md)


### PR DESCRIPTION
## Summary
- Renames "Threshold Monitor" to "Failure Rate Monitor" across all docs
- Adds migration note for API/webhook users: `monitorType` now surfaces as `failure_rate` (previously `threshold`); both accepted as input during transition
- Updates: `flaky-tests/detection/threshold-monitor.md`, `flaky-tests/detection/README.md`, `flaky-tests/get-started/README.md`, `summary.md`

## Source
- trunk2 PR: https://github.com/trunk-io/trunk2/pull/3463

## Test plan
- [ ] Preview in GitBook