### PR TITLE
Fix banned word usage across Merge Queue docs

### DIFF
--- a/merge-queue/administration/advanced-settings.md
+++ b/merge-queue/administration/advanced-settings.md
@@ -333,7 +333,7 @@ Configure how many PRs can be tested simultaneously during batch failure isolati
 #### How to Configure
 
 1. Navigate to **Settings** > **Repositories** > your repository > **Merge Queue** > **Batching**
-2. Ensure **Batching** is enabled
+2. Make sure **Batching** is enabled
 3. Set **Bisection Testing Concurrency** to your desired value
 4. Monitor CI resource usage and adjust as needed
 
@@ -346,7 +346,7 @@ For detailed guidance on using this setting effectively, see [Bisection Testing 
 {% hint style="danger" %}
 CAUTION: Any queued merge requests will not be merged and all data will be lost.
 
-**Before deleting:** Ensure all important PRs in the queue are either merged manually or that you're prepared to resubmit them to a new queue.
+**Before deleting:** Make sure all important PRs in the queue are either merged manually or that you're prepared to resubmit them to a new queue.
 {% endhint %}
 
 This setting will delete the Merge Queue configuration and any queued merge requests will not be merged and all data will be lost.

--- a/merge-queue/administration/metrics.md
+++ b/merge-queue/administration/metrics.md
@@ -28,7 +28,7 @@ In repositories with multiple teams or distinct components (like a TypeScript/Py
 * **Identify bottlenecks by component** - Determine if certain targets have slower merge times
 * **Optimize strategically** - Focus queue configuration improvements on your highest-priority code paths
 * **Demonstrate value** - Show engineering leadership how parallel mode benefits specific teams or projects
-* **Ensure fairness** - Verify that all teams experience similar queue performance
+* **Check fairness** - Verify that all teams experience similar queue performance
 
 #### How to Use the Filter
 
@@ -74,7 +74,7 @@ The date ranges selector at the top left of the dashboard allows you to filter t
 The metrics displayed only include data that have **completed within the time range**, jobs started but not completed during the selected time **will not be displayed**.
 
 {% hint style="info" %}
-When working across multiple time zones, enable **Time in UTC** to ensure everyone sees the same data.
+When working across multiple time zones, enable **Time in UTC** so everyone sees the same data.
 {% endhint %}
 
 ### Conclusion count

--- a/merge-queue/getting-started/README.md
+++ b/merge-queue/getting-started/README.md
@@ -42,7 +42,7 @@ The merge queue needs specific GitHub permissions to function. Follow the [Branc
 
 1. **Configure push restrictions** - Allow the `trunk-io` bot to push to your protected branch
 2. **Disable “Require branches to be up to date before merging.” -** This setting is one of the most common sources of confusion. Many teams enable it to keep their branch green, but it conflicts with how merge queues work. If this is on, PRs will often sit in the “Queued” state forever because GitHub blocks Trunk from updating them.
-3. **Exclude Trunk's temporary branches** - Ensure `trunk-temp/*` and `trunk-merge/*` branches are not protected. They are created and cleaned up automatically by the queue.
+3. **Exclude Trunk's temporary branches** - Make sure `trunk-temp/*` and `trunk-merge/*` branches are not protected. They are created and cleaned up automatically by the queue.
 
 {% hint style="warning" %}
 **Without proper branch protection configuration, the merge queue will not work.** You may see errors like "Permission denied on `trunk-merge/*` branch" or PRs will remain stuck in "Queued" state.
@@ -55,7 +55,7 @@ If you want your organization to merge _exclusively_ through the merge queue:
 * Restrict who can push to your protected branch (e.g., main).
 * Then allow the Trunk GitHub App as the only actor permitted to push to that branch.
 
-This setup ensures all merges flow through the queue and prevents developers from bypassing it accidentally.
+This setup makes sure all merges flow through the queue and prevents developers from bypassing it accidentally.
 
 ### Step 3: Test your setup
 
@@ -85,7 +85,7 @@ If your test PR doesn't merge automatically:
 * **Check the status comments for the PR in** the [Trunk Dashboard](https://app.trunk.io/) to see what it's waiting for
 * **Stuck in "Queued"**: Usually means branch protection rules haven't passed (missing required status checks or code review) or there are merge conflicts. If the status looks correct but the PR still won't enter the queue, try [removing](../using-the-queue/reference.md#submitting-and-cancelling-pull-requests) and re-adding by commenting `/trunk merge` again on the PR.
 * **Fails when attempting to merge**: Check that squash merges are enabled for your repository in GitHub settings (`Settings > General > Allow squash merging`). Trunk Merge Queue requires squash merges to be enabled.
-* **"Permission denied" errors**: Review the [Branch Protection](configure-branch-protection.md) guide to ensure `trunk-temp/*` and `trunk-merge/*` branches aren't protected by wildcard rules like `*/*`.
+* **"Permission denied" errors**: Review the [Branch Protection](configure-branch-protection.md) guide to make sure `trunk-temp/*` and `trunk-merge/*` branches aren't protected by wildcard rules like `*/*`.
 * **Status checks not running**: Verify your CI is configured to run on draft PRs (or `trunk-merge/**` branches if using push-triggered mode). See the [Branch Protection](configure-branch-protection.md) guide for details.
 
 ### Step 4: Configure advanced features

--- a/merge-queue/optimizations/README.md
+++ b/merge-queue/optimizations/README.md
@@ -2,7 +2,7 @@
 
 The core concept of any merge queue is [**Predictive Testing**](predictive-testing.md): testing your pull request against the head of the `main` branch, including all pull requests ahead of it in the queue.
 
-While this is the foundation, achieving the scale necessary to merge thousands of PRs per day requires more advanced strategies. Trunk Merge Queue introduces a suite of powerful concepts designed to maximize throughput and maintain velocity, even in complex, high-traffic repositories. In fact, hitting a high scale is nearly impossible without leveraging features like optimistic merging, pending failure depth, and batching.
+While this is the foundation, achieving the scale necessary to merge thousands of PRs per day requires more advanced strategies. Trunk Merge Queue introduces a set of features designed to maximize throughput and maintain velocity, even in complex, high-traffic repositories. In fact, hitting a high scale is nearly impossible without features like optimistic merging, pending failure depth, and batching.
 
 This section explains each of these key concepts:
 
@@ -10,12 +10,12 @@ This section explains each of these key concepts:
 
 * [**Batching**](batching.md): Groups multiple compatible pull requests together into a single test run. This significantly increases merge throughput and can dramatically reduce CI costs by validating an entire batch with a single test run instead of one for each individual pull request. It is an essential feature for achieving high throughput.
 * [**Parallel Queues**](parallel-queues/): Allows for the creation of multiple independent queues that test and merge PRs in parallel. This feature is necessary for large monorepos and transforms the queue from a simple "line" into a more complex and efficient "graph".
-* [**Testing Concurrency**](../administration/advanced-settings.md#testing-concurrency): A setting that defines the maximum number of pull requests that can be tested simultaneously. Fine-tuning this number is a powerful way to maximize merge velocity. It ensures a continuous flow of validated pull requests by keeping your CI runners fully utilized.
+* [**Testing Concurrency**](../administration/advanced-settings.md#testing-concurrency): A setting that defines the maximum number of pull requests that can be tested simultaneously. Fine-tuning this number maximizes merge velocity. It keeps a continuous flow of validated pull requests moving by keeping your CI runners fully utilized.
 
 #### Resilience and flake handling
 
-* [**Optimistic Merging**](optimistic-merging.md): Increases merge speed by leveraging test results from pull requests that are later in the queue. When a pull request (e.g., pull request 'c') passes testing, its success also verifies the changes from the pull requests ahead of it ('a' and 'b'). This allows the entire group of pull requests to be safely merged at once.
-* [**Pending Failure Depth**](pending-failure-depth.md): When a group fails testing, it enters a Pending Failure state and waits for successor test runs to complete before transitioning. When combined with Optimistic Merging, a passing successor can retroactively clear the failure — enabling automated recovery from transient (flaky) failures without evicting the group from the queue.
+* [**Optimistic Merging**](optimistic-merging.md): Increases merge speed by using test results from pull requests that are later in the queue. When a pull request (e.g., pull request 'c') passes testing, its success also verifies the changes from the pull requests ahead of it ('a' and 'b'). This allows the entire group of pull requests to be safely merged at once.
+* [**Pending Failure Depth**](pending-failure-depth.md): When a group fails testing, it enters a Pending Failure state and waits for successor test runs to complete before transitioning. When combined with Optimistic Merging, a passing successor can retroactively clear the failure, enabling automated recovery from transient (flaky) failures without evicting the group from the queue.
 * [**Anti-Flake Protection**](anti-flake-protection.md): Combining Optimistic Merging and Pending Failure Depth makes the queue more resilient to flaky tests. This inherent outcome allows the successful test of a later pull request to retroactively validate an earlier one that failed due to a transient issue.
 
 {% hint style="success" %}

--- a/merge-queue/optimizations/anti-flake-protection.md
+++ b/merge-queue/optimizations/anti-flake-protection.md
@@ -2,7 +2,7 @@
 
 ### What it is
 
-Some CI jobs fail for reasons unrelated to a PR's code change, such as due to [flaky tests](https://trunk.io/blog/the-ultimate-guide-to-flaky-tests) or a CI runner disconnecting. These failures are usually cleared when the CI job is rerun. If a second PR that depends on the first **does** pass, it is very likely that the first PR was good and simply experienced a transient failure.&#x20;
+Some CI jobs fail for reasons unrelated to a PR's code change, such as due to [flaky tests](https://trunk.io/blog/the-ultimate-guide-to-flaky-tests) or a CI runner disconnecting. These failures are usually cleared when the CI job is rerun. If a second PR that depends on the first **does** pass, it is very likely that the first PR was good and experienced a transient failure.&#x20;
 
 Trunk Merge Queue can use the combination of [**Optimistic Merging** ](optimistic-merging.md)and [**Pending Failure Depth**](pending-failure-depth.md) to merge pull requests that would otherwise be rejected from the queue.
 

--- a/merge-queue/optimizations/batching.md
+++ b/merge-queue/optimizations/batching.md
@@ -40,7 +40,7 @@ Sometimes you need a specific PR to test in isolation, even when batching is ena
 
 * **High-risk changes** — Infrastructure updates, database migrations, or changes that could affect other PRs in unpredictable ways
 * **Debugging batch failures** — Isolate a suspected problematic PR to confirm it tests correctly on its own
-* **Critical hotfixes** — Ensure a time-sensitive fix isn't delayed or affected by other PRs in a batch
+* **Critical hotfixes** — Make sure a time-sensitive fix isn't delayed or affected by other PRs in a batch
 * **Flaky PR isolation** — Test a PR with known flaky behavior separately to avoid impacting other PRs
 
 #### How to exclude a PR from batching
@@ -319,7 +319,7 @@ Together, these features create a highly efficient batch failure recovery system
 
 The downsides here are very limited. Since batching combines multiple pull requests into one, you essentially give up the proof that every pull request in complete isolation can safely be merged into your protected branch.&#x20;
 
-In the unlikely case that you have to revert a change from your protected branch or do a rollback, you will need to retest that revert or submit it to the queue to ensure nothing has broken. In practice, this re-testing is required in almost any case, regardless of how it was originally merged, and the downsides are fairly limited.
+In the unlikely case that you have to revert a change from your protected branch or do a rollback, you will need to retest that revert or submit it to the queue to make sure nothing has broken. In practice, this re-testing is required in almost any case, regardless of how it was originally merged, and the downsides are fairly limited.
 
 #### Common misconceptions
 

--- a/merge-queue/optimizations/direct-merge-to-main.md
+++ b/merge-queue/optimizations/direct-merge-to-main.md
@@ -125,7 +125,7 @@ Direct Merge to Main complements other optimizations:
 
 * When direct merge doesn't trigger, predictive testing takes over
 * PRs not at tip of main test against predicted future state
-* Both features work together seamlessly
+* Both features work together: direct merge handles the tip, predictive testing handles the rest
 
 [**Optimistic Merging**](optimistic-merging.md)
 

--- a/merge-queue/optimizations/optimistic-merging.md
+++ b/merge-queue/optimizations/optimistic-merging.md
@@ -6,7 +6,7 @@ Optimistic merging allows pull requests that fail tests to still get merged if p
 
 The foundation of our merge queue starts with [predictive testing](/broken/pages/BAKgbuxqWos5o4kna99T). When a predictive test is being run, concurrent tests sometimes finish before the work ahead of it. This creates a situation where the system knows that all code ahead of it collectively `passes` tests, and it is safe to merge all those changes into your protected branch (`main)`.\
 \
-With optimistic merging enabled, we can leverage results from pull requests later in the queue to merge faster. In the illustration below you can see that pull request 'c' includes the verified testing results of pull requests 'b' and 'a'. As soon as 'c' passes testing, we can safely merge 'a', 'b', and 'c' and know they will all work correctly together.
+With optimistic merging enabled, the queue uses results from pull requests later in the queue to merge faster. In the illustration below you can see that pull request 'c' includes the verified testing results of pull requests 'b' and 'a'. As soon as 'c' passes testing, we can safely merge 'a', 'b', and 'c' and know they will all work correctly together.
 
 {% embed url="https://share.vidyard.com/watch/5iy2KdNFKHM1Nc13zDv8g8?" %}
 Optimistic merging to merge faster
@@ -41,7 +41,7 @@ After enabling, watch your queue:
 
 The downsides here are very limited. You essentially give up the proof that every pull request in complete isolation can safely be merged into your protected branch.&#x20;
 
-In the unlikely case that you have to revert a change from your protected branch, you will need to retest that revert or submit it to the queue to ensure nothing has broken. In practice, this re-testing is required in almost any case, regardless of how it was originally merged, and the downsides are fairly limited.
+In the unlikely case that you have to revert a change from your protected branch, you will need to retest that revert or submit it to the queue to make sure nothing has broken. In practice, this re-testing is required in almost any case, regardless of how it was originally merged, and the downsides are fairly limited.
 
 #### What you gain
 
@@ -90,7 +90,7 @@ Don't enable optimistic merging if:
 
 **Before enabling optimistic merging:**
 
-1. Ensure basic queue is working well
+1. Make sure basic queue is working well
 2. Verify test stability (< 5% flake rate recommended)
 3. Enable [Anti-flake protection](anti-flake-protection.md) first
 4. Check that you have consistent PR volume

--- a/merge-queue/optimizations/predictive-testing.md
+++ b/merge-queue/optimizations/predictive-testing.md
@@ -26,7 +26,7 @@ Test your pull request with the changes ahead of it in the queue
 
 ### The "Unhappy Path": How the Queue Handles Test Failures
 
-Predictive testing is powerful, but it creates a new challenge: **failure cascades**.
+Predictive testing is effective, but it creates a new challenge: **failure cascades**.
 
 In the "Happy Path" example, if PR `A` introduces a failing test, the predictive tests for `B` and `C` are _also_ guaranteed to fail, because they both include the broken code from `A`.
 

--- a/merge-queue/optimizations/priority-merging.md
+++ b/merge-queue/optimizations/priority-merging.md
@@ -4,7 +4,7 @@
 
 Priority merging allows you to fast-track critical pull requests to the front of the merge queue.&#x20;
 
-By assigning a priority level to a PR, you can ensure urgent changes (like hotfixes, security patches, or critical bug fixes) merge ahead of regular feature work. PRs with higher priority are tested and merged before lower-priority PRs, regardless of when they were submitted.
+By assigning a priority level to a PR, you can make sure urgent changes (like hotfixes, security patches, or critical bug fixes) merge ahead of regular feature work. PRs with higher priority are tested and merged before lower-priority PRs, regardless of when they were submitted.
 
 ### Why use it
 

--- a/merge-queue/reference/common-problems.md
+++ b/merge-queue/reference/common-problems.md
@@ -87,7 +87,7 @@ Features like Optimistic Merging and Batching are validation and testing strateg
 
 Currently, Trunk Merge Queue supports one merge queue per repository. If this is critical for your use case, [talk to us](../../setup-and-administration/support.md) and we'll consider adding support for your use case.
 
-For validating significant changes to your CI process or queue configuration without impacting your primary workflow, the recommended approach is to use a fork of your repository. You can set up and test a separate merge queue on the fork to ensure your changes work as expected before applying them to your primary repository.
+For validating significant changes to your CI process or queue configuration without impacting your primary workflow, the recommended approach is to use a fork of your repository. You can set up and test a separate merge queue on the fork to make sure your changes work as expected before applying them to your primary repository.
 
 </details>
 

--- a/merge-queue/reference/troubleshooting.md
+++ b/merge-queue/reference/troubleshooting.md
@@ -11,7 +11,7 @@ If your test PR doesn't merge automatically:
 * **Check the status comments for the PR in** the [Trunk Dashboard](https://app.trunk.io/) to see what it's waiting for
 * **Stuck in "Queued"**: Usually means branch protection rules haven't passed (missing required status checks or code review) or there are merge conflicts. If the status looks correct but the PR still won't enter the queue, try [removing](/broken/pages/c7O7hgOoGwFcANCdzUMZ#manually-restarting-failed-prs) and re-adding by commenting `/trunk merge` again on the PR.
 * **Fails when attempting to merge**: Check that squash merges are enabled for your repository in GitHub settings (`Settings > General > Allow squash merging`). Trunk Merge Queue requires squash merges to be enabled.
-* **"Permission denied" errors**: Review the [Branch Protection](/broken/pages/zvDo6oVz6lP1OOz5wOUB#configure-branch-protection-rules) guide to ensure `trunk-temp/*` and `trunk-merge/*` branches aren't protected by wildcard rules like `*/*`.
+* **"Permission denied" errors**: Review the [Branch Protection](/broken/pages/zvDo6oVz6lP1OOz5wOUB#configure-branch-protection-rules) guide to make sure `trunk-temp/*` and `trunk-merge/*` branches aren't protected by wildcard rules like `*/*`.
 * **Status checks not running**: Verify your CI is configured to run on draft PRs (or `trunk-merge/**` branches if using push-triggered mode). See the [Branch Protection](/broken/pages/zvDo6oVz6lP1OOz5wOUB#configure-branch-protection-rules) guide for details.
 
 ###
@@ -24,7 +24,7 @@ If your test PR doesn't merge automatically:
 
 **Cause:** Branch protection rules are applying to Trunk's temporary branches.
 
-**Solution:** Follow the "Exclude Trunk's Temporary Branches" section above to ensure `trunk-temp/*` and `trunk-merge/*` are not protected.
+**Solution:** Follow the "Exclude Trunk's Temporary Branches" section above to make sure `trunk-temp/*` and `trunk-merge/*` are not protected.
 
 </details>
 
@@ -38,7 +38,7 @@ If your test PR doesn't merge automatically:
 
 * Click on the pull request in the Trunk Dashboard to see which checks it's waiting for
 * Verify those checks are running in your CI provider
-* If using Push-triggered mode, ensure the check names in `trunk.yaml` exactly match your CI job names
+* If using Push-triggered mode, make sure the check names in `trunk.yaml` exactly match your CI job names
 
 </details>
 
@@ -52,6 +52,6 @@ If your test PR doesn't merge automatically:
 
 * Verify your CI workflows trigger on pushes to `trunk-merge/**` branches
 * Check that the workflows actually ran in your CI provider's interface
-* Ensure the `trunk-io` bot has permission to push to create these branches
+* Make sure the `trunk-io` bot has permission to push to create these branches
 
 </details>


### PR DESCRIPTION
## Summary
Sweep of banned words across 12 Merge Queue documentation pages:
- "leverage/leveraging" → "uses" or removed (3 instances)
- "ensure/ensures" → "make sure/makes sure" (15+ instances)
- "powerful" → "effective" or removed (2 instances)
- "simply" → deleted (1 instance)
- "seamlessly" → replaced with specific description (1 instance)

No semantic changes. Only the wording was updated to match docs style guidelines.

**Files changed:** `getting-started/README.md`, `optimizations/README.md`, `optimizations/batching.md`, `optimizations/optimistic-merging.md`, `optimizations/predictive-testing.md`, `optimizations/anti-flake-protection.md`, `optimizations/direct-merge-to-main.md`, `optimizations/priority-merging.md`, `reference/troubleshooting.md`, `reference/common-problems.md`, `administration/advanced-settings.md`, `administration/metrics.md`

## Test plan
- [ ] Spot-check 2-3 pages on docs.trunk.io after merge to confirm wording reads naturally
- [ ] Grep for remaining banned words in `merge-queue/` to confirm none were missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>