### PR TITLE
Fix product naming and banned word usage in Flaky Tests docs

### DIFF
--- a/flaky-tests/detection/threshold-monitor.md
+++ b/flaky-tests/detection/threshold-monitor.md
@@ -91,9 +91,9 @@ The right minimum depends on how often a test actually runs on the branches you'
 
 How long (in hours) a flagged test can go without any runs before it's automatically resolved as stale. This clears out tests that have been deleted, renamed, or are no longer part of your test suite.
 
-When not set, flagged tests remain in their detected state indefinitely until they run enough times to recover through the normal threshold check. Setting a stale timeout (e.g., 24 hours) ensures abandoned tests don't clutter your test list.
+When not set, flagged tests remain in their detected state indefinitely until they run enough times to recover through the normal threshold check. Setting a stale timeout (e.g., 24 hours) keeps abandoned tests from cluttering your test list.
 
-A test resolved as stale is simply no longer being tracked by this monitor. If the test starts running again and exceeds the activation threshold, it will be re-flagged.
+A test resolved as stale is no longer being tracked by this monitor. If the test starts running again and exceeds the activation threshold, it will be re-flagged.
 
 {% hint style="info" %}
 Skipped tests count as not being run. If you have a stale timeout configured and a test starts being skipped rather than executed, the monitor will treat it as having no runs and resolve it as stale once the timeout elapses.

--- a/flaky-tests/get-started/README.md
+++ b/flaky-tests/get-started/README.md
@@ -27,7 +27,7 @@ Add test result uploads to all CI jobs that run tests.
    * Stable branches (`main`, `master`, `develop`, etc.)
    * Merge queue branches (if applicable)
 
-Uploads from both PRs and stable branches are required for accurate flaky test detection.
+Uploads from both PRs and stable branches are required for Trunk Flaky Tests to accurately detect flaky tests.
 
 #### Step 3: Verify integration
 
@@ -45,7 +45,7 @@ After uploads are flowing, navigate to your repo → **Flaky Tests > Monitors** 
 
 **Threshold monitors** let you detect flakiness based on failure rate over a rolling time window. How you configure them depends on your CI setup:
 
-- **If tests must pass before merging to main**, set up a threshold monitor scoped to `main` to catch an elevated failure rate. For example, if you run tests 5 times per day on `main`, a 24-hour rolling window with a minimum of 4 runs and a failure threshold of 25% is a reasonable starting point. This ensures the monitor has enough data before flagging anything.
+- **If tests must pass before merging to main**, set up a threshold monitor scoped to `main` to catch an elevated failure rate. For example, if you run tests 5 times per day on `main`, a 24-hour rolling window with a minimum of 4 runs and a failure threshold of 25% is a reasonable starting point. This gives the monitor enough data before flagging anything.
 - **If you use a merge queue**, consider a dedicated monitor scoped to your merge queue branches (e.g., `trunk-merge/*` or `gh-readonly-queue/*`). Failures here are especially suspicious since the code has already passed PR checks, so a low threshold is appropriate.
 
 [How threshold monitors work →](../detection/threshold-monitor.md)

--- a/flaky-tests/get-started/ci-providers/bitbucket-pipelines.md
+++ b/flaky-tests/get-started/ci-providers/bitbucket-pipelines.md
@@ -64,7 +64,7 @@ pipelines:
         script:
           - &#x3C;COMMAND TO RUN TESTS>
         after-script:
-          # This ensures trunk upload runs even if the test script fails
+          # trunk upload runs even if the test script fails
           - |
             curl -fL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/latest/download/trunk-analytics-cli-x86_64-unknown-linux.tar.gz" | tar -xz
             chmod +x trunk-analytics-cli
@@ -87,7 +87,7 @@ pipelines:
         script:
           - <COMMAND TO RUN TESTS>
         after-script:
-          # This ensures trunk upload runs even if the test script fails
+          # trunk upload runs even if the test script fails
           - |
             curl -fL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/latest/download/trunk-analytics-cli-x86_64-unknown-linux.tar.gz" | tar -xz
             chmod +x trunk-analytics-cli
@@ -110,7 +110,7 @@ pipelines:
         script:
           - <COMMAND TO RUN TESTS>
         after-script:
-          # This ensures trunk upload runs even if the test script fails
+          # trunk upload runs even if the test script fails
           - |
             curl -fL --retry 3 "https://github.com/trunk-io/analytics-cli/releases/latest/download/trunk-analytics-cli-x86_64-unknown-linux.tar.gz" | tar -xz
             chmod +x trunk-analytics-cli

--- a/flaky-tests/get-started/ci-providers/github-actions.md
+++ b/flaky-tests/get-started/ci-providers/github-actions.md
@@ -165,7 +165,7 @@ jobs:
       id: unit_tests
       shell: bash
 <strong>      run: &#x3C;COMMAND TO RUN TESTS> # command to run tests goes here
-</strong><strong>      continue-on-error: true # ensure CI job continues to upload step on errors
+</strong><strong>      continue-on-error: true # allow CI job to continue to upload step on errors
 </strong>        
     - name: Upload test results
       if: always()
@@ -205,7 +205,7 @@ jobs:
 **Using Flaky Tests as a separate step**
 
 {% hint style="warning" %}
-If you upload your test results as a second step after you run your tests, you need to ensure your test step **continues on errors** so the upload step that's run after can quarantine failed tests.&#x20;
+If you upload your test results as a second step after you run your tests, you need to make sure your test step **continues on errors** so the upload step that's run after can quarantine failed tests.&#x20;
 
 When quarantining is enabled, the `trunk-analytics-cli upload` command will **return an error** if there are unquarantined failures and return a status code 0 if all tests are quarantined.
 {% endhint %}

--- a/flaky-tests/get-started/frameworks/gotestsum.md
+++ b/flaky-tests/get-started/frameworks/gotestsum.md
@@ -9,7 +9,7 @@ You can automatically [detect and manage flaky tests](../../detection/) in your 
 
 ### **Why an Extra Step for `go test`?**
 
-The standard Go test runner, `go test`, is excellent for executing tests and providing immediate feedback to developers. However, it does not natively produce test reports in the JUnit XML format that Trunk Flaky Tests requires for ingestion and analysis. Therefore, an additional tool is needed to convert the output of `go test` into this compatible format. This intermediate step ensures that Trunk can accurately process your test results and identify flaky tests.
+The standard Go test runner, `go test`, is excellent for executing tests and providing immediate feedback to developers. However, it does not natively produce test reports in the JUnit XML format that Trunk Flaky Tests requires for ingestion and analysis. Therefore, an additional tool is needed to convert the output of `go test` into this compatible format. This intermediate step allows Trunk to accurately process your test results and identify flaky tests.
 
 ### Checklist
 

--- a/flaky-tests/get-started/frameworks/rspec/README.md
+++ b/flaky-tests/get-started/frameworks/rspec/README.md
@@ -60,7 +60,7 @@ If you have a step in CI to rerun failed tests with the `--only-failures` option
 
 #### Versions and Updating the Plugin
 
-You can find the Gem for `rspec_trunk_flaky_tests` [here](https://rubygems.org/gems/rspec_trunk_flaky_tests), along with its version history. This plugin is periodically updated for more robust support and bug fixes, and if you're encountering something unexpected, we first encourage you to:
+You can find the Gem for `rspec_trunk_flaky_tests` [here](https://rubygems.org/gems/rspec_trunk_flaky_tests), along with its version history. This plugin is periodically updated with improved support and bug fixes. If you're encountering something unexpected, first try:
 
 ```
 bundle update rspec_trunk_flaky_tests

--- a/flaky-tests/get-started/frameworks/vitest.md
+++ b/flaky-tests/get-started/frameworks/vitest.md
@@ -82,13 +82,13 @@ If you've enabled retries, you can disable them following the [Vitest docs](http
 1. **Check TypeScript Configuration**: Ensure your `tsconfig.json` is valid and includes all necessary paths
 2. **Verify Dependencies**: Make sure all imported modules are properly installed and accessible
 3. **Review Setup Files**: Check any test setup files referenced in your Vitest config for errors
-4. **Validate Vitest Config**: Ensure your `vitest.config.ts` doesn't contain invalid options
+4. **Validate Vitest Config**: Make sure your `vitest.config.ts` doesn't contain invalid options
 
 ### Try It Locally
 
 #### Validate Test Execution First
 
-Before validating your JUnit reports with Trunk, ensure Vitest can properly execute your tests:
+Before validating your JUnit reports with Trunk, make sure Vitest can properly execute your tests:
 
 ```bash
 # Run tests with detailed output to catch configuration issues

--- a/flaky-tests/infrastructure-failure-protection.md
+++ b/flaky-tests/infrastructure-failure-protection.md
@@ -1,7 +1,7 @@
 ---
 description: >-
-  Prevent false flaky test detections during CI outages and infrastructure
-  failures.
+  Prevent false Trunk Flaky Tests detections during CI outages and
+  infrastructure failures.
 ---
 
 # Infrastructure Failure Protection
@@ -12,9 +12,9 @@ When infrastructure issues like database outages, network problems, or CI runner
 
 ### How it works
 
-Trunk monitors the failure rate of each test upload. If the percentage of failing tests exceeds your configured threshold, that upload is flagged as an infrastructure failure and excluded from flaky test detection.
+Trunk monitors the failure rate of each test upload. If the percentage of failing tests exceeds your configured threshold, that upload is flagged as an infrastructure failure and excluded from Trunk Flaky Tests detection.
 
-For example, if your threshold is set to 80% and a CI run has 85% of tests failing (this could be due to a database being unavailable or similar infrastructure issue, etc) that entire run will be excluded from flaky test detection. This prevents tests from being incorrectly marked as flaky when they're retried and pass.
+For example, if your threshold is set to 80% and a CI run has 85% of tests failing (this could be due to a database being unavailable or similar infrastructure issue, etc) that entire run will be excluded from Trunk Flaky Tests detection. This prevents tests from being incorrectly marked as flaky when they're retried and pass.
 
 {% hint style="info" %}
 Uploads excluded due to infrastructure failure protection will appear in the **Uploads** tab with the status **"Upload Skipped Due to Infrastructure Error."**

--- a/flaky-tests/managing-detected-flaky-tests.md
+++ b/flaky-tests/managing-detected-flaky-tests.md
@@ -6,7 +6,7 @@ description: >-
 
 # Managing detected flaky tests
 
-It is important to have a follow-up process in place to manage detected flaky tests. A good process ensures that flaky tests do not slow down CI for your development team and prevents flakes from accumulating over time.&#x20;
+It is important to have a follow-up process in place to manage detected flaky tests. A good process makes sure flaky tests do not slow down CI for your development team and prevents flakes from accumulating over time.&#x20;
 
 This guide walks through Trunk's recommended best practices for building a process around detected flaky tests in your organization.
 

--- a/flaky-tests/quarantine-service-availability.md
+++ b/flaky-tests/quarantine-service-availability.md
@@ -28,4 +28,4 @@ We prioritize avoiding false positives over convenience. If Trunk is down, we'd 
 
 #### Caching behavior
 
-Trunk Analytics CLI does not cache quarantine configuration locally. Each invocation requires a successful API call to apply quarantining. This ensures you're always operating on the freshest quarantine state rather than potentially stale data.
+Trunk Analytics CLI does not cache quarantine configuration locally. Each invocation requires a successful API call to apply quarantining. This means you are always operating on the freshest quarantine state rather than potentially stale data.

--- a/flaky-tests/the-importance-of-pr-test-results.md
+++ b/flaky-tests/the-importance-of-pr-test-results.md
@@ -28,7 +28,7 @@ If you don't upload test results from PRs:
 
 #### Unblocking Developers with Quarantining
 
-Quarantining is one of the most powerful features of Trunk Flaky Tests. Its core purpose is to prevent known flaky tests from blocking developers and breaking CI pipelines, especially merge queues.
+Quarantining is one of the most important features of Trunk Flaky Tests. Its core purpose is to prevent known flaky tests from blocking developers and breaking CI pipelines, especially merge queues.
 
 The entire quarantining workflow is predicated on analyzing test results from PRs. Without PR data, you cannot:
 
@@ -57,7 +57,7 @@ These comments provide a summary of all tests run on a specific PR, highlighting
 
 #### Next Steps: Enable PR Uploads
 
-Now that you understand why uploading test results from pull requests is essential, the next step is to configure your CI pipeline. This single step is the key to unlocking accurate flakiness detection, true impact measurement, and powerful features like quarantining.
+Now that you understand why uploading test results from pull requests is essential, the next step is to configure your CI pipeline. This single step is the key to accurate flakiness detection, true impact measurement, and features like quarantining.
 
 Our documentation provides step-by-step guides for all major CI providers to make this setup simple.
 

--- a/flaky-tests/uploader.md
+++ b/flaky-tests/uploader.md
@@ -242,7 +242,7 @@ Running tests via `trunk-analytics-cli test` adds negligible memory overhead.
 
 This subcommand is a thin wrapper around your existing test command and doesn't modify or parallelize test execution.
 
-During execution, it simply:
+During execution, it:
 
 * Runs your provided test command directly.
 * Records start and end times.

--- a/flaky-tests/use-mcp-server/mcp-tool-reference/set-up-test-uploads.md
+++ b/flaky-tests/use-mcp-server/mcp-tool-reference/set-up-test-uploads.md
@@ -6,7 +6,7 @@ description: 'MCP tool reference: setup-trunk-uploads'
 
 ### Overview
 
-The `setup-trunk-uploads` tool helps configure test result uploads to Trunk for flaky test detection and enhanced CI Autopilot analysis. This tool provides step-by-step instructions tailored to your specific test framework and CI provider combination.
+The `setup-trunk-uploads` tool helps configure test result uploads to Trunk Flaky Tests. This tool provides step-by-step instructions tailored to your specific test framework and CI provider combination.
 
 
 

--- a/flaky-tests/use-mcp-server/mcp-tool-reference/set-up-test-uploads.md
+++ b/flaky-tests/use-mcp-server/mcp-tool-reference/set-up-test-uploads.md
@@ -6,7 +6,7 @@ description: 'MCP tool reference: setup-trunk-uploads'
 
 ### Overview
 
-The `setup-trunk-uploads` tool helps configure test result uploads to Trunk Flaky Tests. This tool provides step-by-step instructions tailored to your specific test framework and CI provider combination.
+The `setup-trunk-uploads` tool helps configure test result uploads for Trunk Flaky Tests. This tool provides step-by-step instructions tailored to your specific test framework and CI provider combination.
 
 
 


### PR DESCRIPTION
## Summary
Two categories of fixes across 13 Flaky Tests documentation pages:

**Product naming:**
- "flaky test detection" → "Trunk Flaky Tests" (proper product name)
- "flaky test detections" → "Trunk Flaky Tests detections" (3 instances in infrastructure-failure-protection.md)

**Banned words:**
- "ensures" → context-appropriate alternatives ("makes sure", "gives", "keeps", "means", "allows")
- "robust" → "improved"
- "simply" → deleted
- "powerful" → "important"
- "ensure" → "make sure"
- "we first encourage you to" → "first try"

**Files changed:** 13 files across `flaky-tests/` including get-started frameworks, CI providers, detection, and overview pages.

## Test plan
- [ ] Spot-check 2-3 pages on docs.trunk.io after merge
- [ ] Grep for remaining "CI Autopilot" references in `flaky-tests/` (separate from MCP server fixes in #542)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>