### PR TITLE
Add frontmatter descriptions to 7 Flaky Tests pages

### DIFF
--- a/flaky-tests/flaky-tests.md
+++ b/flaky-tests/flaky-tests.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  REST API for checking Trunk service status and fetching unhealthy or
+  quarantined tests in your project.
+---
+
 # Flaky Tests API
 
 The Trunk Flaky Tests API provides access to check the status of Trunk services and fetch [unhealthy](detection/) or [quarantined](quarantining.md) tests in your project. The API is an HTTP REST API, returns JSON from all requests, and uses standard HTTP response codes.

--- a/flaky-tests/get-started/README.md
+++ b/flaky-tests/get-started/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Set up Trunk Flaky Tests by configuring test result output, uploading from
+  CI, and enabling flake detection monitors.
+---
+
 # Getting Started
 
 Trunk Flaky Tests detects flaky tests by analyzing test results from your CI runs. Setup requires configuring test result output and CI upload integration.

--- a/flaky-tests/quarantine-service-availability.md
+++ b/flaky-tests/quarantine-service-availability.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  How Trunk Analytics CLI handles quarantine service outages without
+  compromising your CI pipeline.
+---
+
 # Quarantine Service Availability
 
 ### Service Availability and Graceful Degradation

--- a/flaky-tests/the-importance-of-pr-test-results.md
+++ b/flaky-tests/the-importance-of-pr-test-results.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Why uploading test results from pull requests is required for accurate
+  flaky test detection, quarantining, and impact measurement.
+---
+
 # The Importance of PR Test Results
 
 Uploading test results from pull requests (PRs) is a critical step for enabling Trunk Flaky Tests. This data provides a primary signal for _detecting_ flaky tests and is the key metric for _measuring_ their impact. Without it, you lose the most significant source of information for identifying and prioritizing these disruptive tests.

--- a/flaky-tests/uploader.md
+++ b/flaky-tests/uploader.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  CLI tool for uploading test results to Trunk from CI, enabling flaky test
+  detection and quarantining.
+---
+
 # Trunk Analytics CLI
 
 Trunk detects and tracks flaky tests in your repos by receiving uploads from your test runs in CI, uploaded from the Trunk Analytics CLI. These uploads happen in the CI jobs used to run tests in your nightly CI, post-commit jobs, and PR checks.

--- a/flaky-tests/use-mcp-server/configuration/README.md
+++ b/flaky-tests/use-mcp-server/configuration/README.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Configure your AI application to connect to the Trunk MCP server for
+  flaky test insights and setup assistance.
+---
+
 # Configuration
 
 <table data-view="cards"><thead><tr><th align="center"></th><th data-hidden data-card-cover data-type="image">Cover image</th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td align="center"><strong>Claude Code</strong></td><td><a href="../../../../.gitbook/assets/claude.png">claude.png</a></td><td><a href="claude-code-cli.md">claude-code-cli.md</a></td></tr><tr><td align="center"><strong>Cursor</strong></td><td><a href="../../../../.gitbook/assets/cursor.png">cursor.png</a></td><td><a href="cursor-ide.md">cursor-ide.md</a></td></tr><tr><td align="center"><strong>GitHub Copilot</strong></td><td><a href="../../../../.gitbook/assets/github copilot.png">github copilot.png</a></td><td><a href="github-copilot-ide.md">github-copilot-ide.md</a></td></tr><tr><td align="center"><strong>Gemini</strong></td><td><a href="../../../../.gitbook/assets/gemini.png">gemini.png</a></td><td><a href="gemini-cli.md">gemini-cli.md</a></td></tr></tbody></table>

--- a/flaky-tests/use-mcp-server/mcp-tool-reference/README.md
+++ b/flaky-tests/use-mcp-server/mcp-tool-reference/README.md
@@ -1,2 +1,8 @@
+---
+description: >-
+  Reference documentation for tools exposed by the Trunk MCP server,
+  including flaky test analysis and upload setup.
+---
+
 # MCP Tool Reference
 


### PR DESCRIPTION
## Summary
Add `description` frontmatter to 7 Flaky Tests pages that were missing it. Each description is <=160 characters.

**Pages updated:**
- `flaky-tests/flaky-tests.md` — REST API reference
- `flaky-tests/uploader.md` — CLI tool for uploading test results
- `flaky-tests/the-importance-of-pr-test-results.md` — Why PR uploads are required
- `flaky-tests/quarantine-service-availability.md` — Outage handling
- `flaky-tests/get-started/README.md` — Setup overview
- `flaky-tests/use-mcp-server/configuration/README.md` — MCP server configuration
- `flaky-tests/use-mcp-server/mcp-tool-reference/README.md` — MCP tool reference

## Test plan
- [ ] Verify frontmatter renders correctly in GitBook preview (Change Request)
- [ ] Confirm descriptions appear in page metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>