### PR TITLE
Rename Threshold Monitor to Failure Rate Monitor

### DIFF
--- a/flaky-tests/detection/README.md
+++ b/flaky-tests/detection/README.md
@@ -12,8 +12,8 @@ Each monitor independently observes your test runs and tracks two states per tes
 
 | Priority | Status | Condition |
 |----------|--------|-----------|
-| Highest | **Broken** | Any enabled broken-type monitor (threshold or failure count) is active for this test |
-| Middle | **Flaky** | Any enabled flaky-type monitor (threshold, failure count, or pass-on-retry) is active |
+| Highest | **Broken** | Any enabled broken-type monitor (failure rate or failure count) is active for this test |
+| Middle | **Flaky** | Any enabled flaky-type monitor (failure rate, failure count, or pass-on-retry) is active |
 | Lowest | **Healthy** | No active monitors |
 
 If a test triggers both a broken monitor and a flaky monitor simultaneously, it shows as **Broken**. When the broken monitor resolves (e.g., you fix the regression and the failure rate drops), the test transitions to **Flaky** if a flaky monitor is still active, or to **Healthy** if no monitors remain active.
@@ -24,19 +24,19 @@ A test stays in its detected state until every relevant monitor that flagged it 
 
 When you disable or delete a monitor, it is immediately set to **resolved** for every test case in the repo. This triggers a status re-evaluation for all affected tests. If the disabled monitor was the only active monitor for a test, that test transitions to healthy. If other monitors are still active, the test remains in the most severe active state.
 
-For example, if you have a broken threshold monitor and a flaky pass-on-retry monitor, and you disable the broken monitor, any test that was only flagged by the broken monitor will become healthy. A test flagged by both will transition from broken to flaky (because pass-on-retry is still active).
+For example, if you have a broken failure rate monitor and a flaky pass-on-retry monitor, and you disable the broken monitor, any test that was only flagged by the broken monitor will become healthy. A test flagged by both will transition from broken to flaky (because pass-on-retry is still active).
 
 ## Monitor Types
 
 | Monitor | What it detects | Detection type | Plan availability | Default state |
 |---|---|---|---|---|
 | [**Pass-on-Retry**](pass-on-retry-monitor.md) | A test fails then passes on the same commit (retry after failure) | Flaky | Team and above | Enabled |
-| [**Threshold**](threshold-monitor.md) | Failure rate exceeds a configured percentage over a time window | Flaky or Broken | Paid plans | Disabled |
+| [**Failure Rate**](failure-rate-monitor.md) | Failure rate exceeds a configured percentage over a time window | Flaky or Broken | Paid plans | Disabled |
 | [**Failure Count**](failure-count-monitor.md) | A test accumulates a configured number of failures in a rolling window | Flaky or Broken | Paid plans | Disabled |
 
-You can run multiple monitors simultaneously. For example, you might use pass-on-retry to catch classic retry-based flakiness while also running threshold monitors scoped to different branches. A common pattern is to pair a broken-type threshold monitor (catching consistently failing tests) with a flaky-type threshold monitor (catching intermittently failing tests). See [Threshold Monitor: Recommended Configurations](threshold-monitor.md#recommended-configurations) for details.
+You can run multiple monitors simultaneously. For example, you might use pass-on-retry to catch classic retry-based flakiness while also running failure rate monitors scoped to different branches. A common pattern is to pair a broken-type failure rate monitor (catching consistently failing tests) with a flaky-type failure rate monitor (catching intermittently failing tests). See [Failure Rate Monitor: Recommended Configurations](failure-rate-monitor.md#recommended-configurations) for details.
 
-The [failure count monitor](failure-count-monitor.md) complements threshold monitors by reacting to individual failures rather than failure rates. Use it on branches where any failure is a meaningful signal, like `main` or merge queue branches.
+The [failure count monitor](failure-count-monitor.md) complements failure rate monitors by reacting to individual failures rather than failure rates. Use it on branches where any failure is a meaningful signal, like `main` or merge queue branches.
 
 If you need to manually flag a test that automated monitors haven't caught, use [Flag as Flaky](flag-as-flaky.md) from the test detail page.
 
@@ -44,7 +44,7 @@ If you need to manually flag a test that automated monitors haven't caught, use 
 
 Tests often behave differently depending on where they run. Failures on `main` are usually unexpected and signal flakiness. Failures on PR branches may be expected during active development. Merge queue failures are suspicious because the code has already passed PR checks.
 
-Rather than applying a single set of branch rules automatically, Trunk gives you control over how detection treats different branches through **branch scoping** on threshold monitors. You can create separate monitors with different thresholds and windows for your stable branch, PR branches, and merge queue branches. See [Threshold Monitor: Recommended configurations](threshold-monitor.md#recommended-configurations) for specific guidance.
+Rather than applying a single set of branch rules automatically, Trunk gives you control over how detection treats different branches through **branch scoping** on failure rate monitors. You can create separate monitors with different thresholds and windows for your stable branch, PR branches, and merge queue branches. See [Failure Rate Monitor: Recommended configurations](failure-rate-monitor.md#recommended-configurations) for specific guidance.
 
 Pass-on-retry detection is branch-agnostic. It flags any test that fails and passes on the same commit, regardless of which branch the test ran on.
 

--- a/flaky-tests/detection/failure-count-monitor.md
+++ b/flaky-tests/detection/failure-count-monitor.md
@@ -4,7 +4,7 @@ description: Detect flaky or broken tests as soon as they accumulate a configure
 
 # Failure Count Monitor
 
-The failure count monitor flags a test the moment it accumulates a configured number of failures on monitored branches within a rolling time window. Unlike the threshold monitor, which requires a failure *rate* calculated over many runs, the failure count monitor reacts to individual failures without needing a minimum sample size or a percentage calculation.
+The failure count monitor flags a test the moment it accumulates a configured number of failures on monitored branches within a rolling time window. Unlike the failure rate monitor, which requires a failure *rate* calculated over many runs, the failure count monitor reacts to individual failures without needing a minimum sample size or a percentage calculation.
 
 This makes it well-suited for stable branches like `main` where any test failure is unexpected and worth investigating immediately.
 
@@ -13,10 +13,10 @@ This makes it well-suited for stable branches like `main` where any test failure
 Use the failure count monitor when you want immediate visibility into test failures on branches that should be green. Common scenarios:
 
 - **Stable branch alerting:** Flag any test that fails on `main`, even once. On a branch where all tests should pass, a single failure is a meaningful signal.
-- **Post-merge regression detection:** Catch tests that start failing after a merge, before the failure rate accumulates enough data for a threshold monitor to trigger.
+- **Post-merge regression detection:** Catch tests that start failing after a merge, before the failure rate accumulates enough data for a failure rate monitor to trigger.
 - **High-confidence branches:** Monitor merge queue or release branches where failures are suspicious by definition.
 
-If you need to detect patterns of intermittent failure over time (e.g., a test that fails 20% of the time), use a [threshold monitor](threshold-monitor.md) instead. If you want to catch tests that fail and then pass on retry within a single commit, [pass-on-retry](pass-on-retry-monitor.md) handles that automatically.
+If you need to detect patterns of intermittent failure over time (e.g., a test that fails 20% of the time), use a [failure rate monitor](failure-rate-monitor.md) instead. If you want to catch tests that fail and then pass on retry within a single commit, [pass-on-retry](pass-on-retry-monitor.md) handles that automatically.
 
 ## Detection Type
 
@@ -72,7 +72,7 @@ The window should be long enough to capture the failures you care about but shor
 
 ### Resolution Timeout
 
-How long a flagged test must go without any new failures before it is automatically resolved. This is the only way a failure count monitor resolves. There is no "recovery rate" or sample-based resolution like the threshold monitor.
+How long a flagged test must go without any new failures before it is automatically resolved. This is the only way a failure count monitor resolves. There is no "recovery rate" or sample-based resolution like the failure rate monitor.
 
 For example, with a resolution timeout of 2 hours, a test that was flagged at 3:00 PM will resolve at 5:00 PM if no new failures occur. If a new failure arrives at 4:30 PM, the clock resets, and the test will not resolve until 6:30 PM.
 
@@ -84,7 +84,7 @@ Choose a resolution timeout that gives your team enough time to verify a fix has
 
 Which branches the monitor evaluates. You can specify branch names or glob patterns. Only test failures on matching branches count toward the failure count.
 
-Branch patterns work the same way as [threshold monitor branch patterns](threshold-monitor.md#branch-pattern-syntax), including glob syntax and merge queue patterns. Refer to that section for pattern syntax, examples, and tips.
+Branch patterns work the same way as [failure rate monitor branch patterns](failure-rate-monitor.md#branch-pattern-syntax), including glob syntax and merge queue patterns. Refer to that section for pattern syntax, examples, and tips.
 
 ## Resolution Behavior
 

--- a/flaky-tests/detection/failure-rate-monitor.md
+++ b/flaky-tests/detection/failure-rate-monitor.md
@@ -2,15 +2,15 @@
 description: Detect flaky or broken tests based on failure rate over a configurable time window
 ---
 
-# Threshold Monitor
+# Failure Rate Monitor
 
-The threshold monitor detects tests based on failure rate over a rolling time window. Unlike pass-on-retry, which looks for a specific pattern on a single commit, the threshold monitor identifies tests that fail too often over a period of time, even if no individual failure looks like a retry.
+The failure rate monitor detects tests based on failure rate over a rolling time window. Unlike pass-on-retry, which looks for a specific pattern on a single commit, the failure rate monitor identifies tests that fail too often over a period of time, even if no individual failure looks like a retry.
 
-You can create multiple threshold monitors with different configurations. This is how you tailor detection to different branches, test volumes, sensitivity levels, and detection types.
+You can create multiple failure rate monitors with different configurations. This is how you tailor detection to different branches, test volumes, sensitivity levels, and detection types.
 
 ## Detection Type
 
-Each threshold monitor has a **detection type** — either **flaky** or **broken** — which controls what status a test receives when the monitor flags it:
+Each failure rate monitor has a **detection type** — either **flaky** or **broken** — which controls what status a test receives when the monitor flags it:
 
 - **Flaky monitors** catch tests that fail intermittently (e.g., 20–50% failure rate). These are typically caused by timing issues, shared state, or non-deterministic behavior.
 - **Broken monitors** catch tests that fail consistently at a high rate (e.g., 80%+ failure rate). These usually indicate a real regression — something in the code or environment is genuinely broken and needs a fix.
@@ -25,7 +25,7 @@ The monitor periodically calculates the failure rate for each test within a time
 
 ### Example
 
-You configure a threshold monitor with:
+You configure a failure rate monitor with:
 
 | Setting | Value |
 |---|---|
@@ -46,7 +46,7 @@ Over the last 6 hours, here's what the monitor observes:
 
 ## Configuration
 
-<!-- SCREENSHOT: Threshold monitor creation form.
+<!-- SCREENSHOT: Failure rate monitor creation form.
 Show the full creation form with all fields visible: detection type, name,
 activation threshold, resolution threshold, window duration, minimum sample size,
 stale timeout, and branch scope. Capture it with realistic example values filled
@@ -175,11 +175,11 @@ Tests that are still running but haven't accumulated enough runs to meet the min
 
 ## Muting
 
-You can temporarily mute a threshold monitor for a specific test case. See [Muting monitors](README.md#muting-monitors) for details.
+You can temporarily mute a failure rate monitor for a specific test case. See [Muting monitors](README.md#muting-monitors) for details.
 
 ## Recommended Configurations
 
-A common setup is to pair two threshold monitors — one to catch broken tests quickly and one to catch flaky tests over a longer window:
+A common setup is to pair two failure rate monitors — one to catch broken tests quickly and one to catch flaky tests over a longer window:
 
 | Monitor | Detection type | Activation threshold | Window | Purpose |
 |---------|---------------|---------------------|--------|---------|
@@ -206,7 +206,7 @@ Failures on your stable branch are a strong signal. Tests should be passing befo
 
 On PR branches, tests are expected to fail — that's part of active development. Analyzing failure rate for flakiness on PRs is generally not productive because a new failing test is likely caused by the code change under review, not non-deterministic behavior. Pass-on-retry already handles real flakiness on PRs: if a test fails and then passes on retry within the same commit, it will be detected regardless of branch.
 
-If you do want a threshold monitor on PRs, scope it to catch **broken** tests rather than flaky ones — tests that are consistently failing at a high rate across many PRs, which may indicate a persistent regression or a broken test environment.
+If you do want a failure rate monitor on PRs, scope it to catch **broken** tests rather than flaky ones — tests that are consistently failing at a high rate across many PRs, which may indicate a persistent regression or a broken test environment.
 
 | Setting | Suggested value | Why |
 |---|---|---|
@@ -245,8 +245,8 @@ Common branch patterns for merge queues:
 - **Release branches:** A monitor scoped to `release/*` with strict thresholds catches flakiness before it ships.
 - **Nightly or scheduled builds:** If you run comprehensive test suites on a schedule, a monitor with a longer window and higher minimum sample size can catch slow-burn flakiness that doesn't show up in faster CI runs.
 
-<!-- SCREENSHOT: Monitor overview page with multiple threshold monitors.
-Show the monitors list/card view with two or three configured threshold
+<!-- SCREENSHOT: Monitor overview page with multiple failure rate monitors.
+Show the monitors list/card view with two or three configured failure rate
 monitors visible (e.g., "Broken on main", "Flaky on main", "Merge queue"),
 displaying their key settings at a glance (detection type, threshold,
 window, branch scope). Include the pass-on-retry monitor card as well

--- a/flaky-tests/get-started/README.md
+++ b/flaky-tests/get-started/README.md
@@ -49,12 +49,12 @@ After uploads are flowing, navigate to your repo → **Flaky Tests > Monitors** 
 
 **Pass-on-retry** is enabled by default and is the recommended baseline for everyone. It catches the most common flakiness pattern — a test that fails and then passes on retry within the same commit — without any configuration needed.
 
-**Threshold monitors** let you detect flakiness based on failure rate over a rolling time window. How you configure them depends on your CI setup:
+**Failure rate monitors** let you detect flakiness based on failure rate over a rolling time window. How you configure them depends on your CI setup:
 
-- **If tests must pass before merging to main**, set up a threshold monitor scoped to `main` to catch an elevated failure rate. For example, if you run tests 5 times per day on `main`, a 24-hour rolling window with a minimum of 4 runs and a failure threshold of 25% is a reasonable starting point. This gives the monitor enough data before flagging anything.
+- **If tests must pass before merging to main**, set up a failure rate monitor scoped to `main` to catch an elevated failure rate. For example, if you run tests 5 times per day on `main`, a 24-hour rolling window with a minimum of 4 runs and a failure threshold of 25% is a reasonable starting point. This gives the monitor enough data before flagging anything.
 - **If you use a merge queue**, consider a dedicated monitor scoped to your merge queue branches (e.g., `trunk-merge/*` or `gh-readonly-queue/*`). Failures here are especially suspicious since the code has already passed PR checks, so a low threshold is appropriate.
 
-[How threshold monitors work →](../detection/threshold-monitor.md)
+[How failure rate monitors work →](../detection/failure-rate-monitor.md)
 
 #### Quarantining
 

--- a/summary.md
+++ b/summary.md
@@ -97,7 +97,7 @@
 * [Dashboard](flaky-tests/dashboard.md)
 * [Flaky test detection](flaky-tests/detection/README.md)
   * [Pass-on-Retry Monitor](flaky-tests/detection/pass-on-retry-monitor.md)
-  * [Threshold Monitor](flaky-tests/detection/threshold-monitor.md)
+  * [Failure Rate Monitor](flaky-tests/detection/failure-rate-monitor.md)
   * [Failure Count Monitor](flaky-tests/detection/failure-count-monitor.md)
   * [Flag as Flaky](flaky-tests/detection/flag-as-flaky.md)
 * [Infrastructure Failure Protection](flaky-tests/infrastructure-failure-protection.md)


### PR DESCRIPTION
## Summary

Renames the Threshold Monitor page to Failure Rate Monitor per semi-urgent docs request. All copy stays the same, only the product name changes.

- `threshold-monitor.md` → `failure-rate-monitor.md` (via `git mv` so GitBook redirect is preserved)
- "Threshold Monitor" / "threshold monitor(s)" → "Failure Rate Monitor" / "failure rate monitor(s)"
- Cross-refs updated in `detection/README.md`, `get-started/README.md`, `failure-count-monitor.md`, and `summary.md`
- Preserved field names: "activation threshold", "resolution threshold", "failure threshold"

## Test plan

- [ ] GitBook Change Request preview renders the renamed page
- [ ] Sidebar shows "Failure Rate Monitor" under Flake Detection
- [ ] Internal links from related pages resolve to the new slug
- [ ] Old `threshold-monitor` URL redirects to the new page

🤖 Generated with [Claude Code](https://claude.com/claude-code)