### PR TITLE
Clarify CI configuration for Merge Queue testing modes

### DIFF
--- a/merge-queue/administration/advanced-settings.md
+++ b/merge-queue/administration/advanced-settings.md
@@ -223,7 +223,7 @@ There are three ways to tell Merge Queue which status checks to wait on while te
 All three work regardless of which testing mode you chose (Draft PR or Push-Triggered).
 
 {% hint style="info" %}
-**This controls which checks gate merging while a PR is being tested in the queue. It does not control which PRs are admitted into the queue.**
+**These checks are what Merge Queue waits on while a PR is already in the queue and testing. They do not control which PRs are admitted into the queue.**
 {% endhint %}
 
 **When to override the default:**

--- a/merge-queue/administration/advanced-settings.md
+++ b/merge-queue/administration/advanced-settings.md
@@ -214,15 +214,26 @@ For example, assuming a timeout of 4 hours:
 
 > Configure which CI status checks must pass before a PR can merge through the queue.
 
-By default, Trunk infers required status checks from your GitHub branch protection rules. You can override this by configuring required statuses directly in the Trunk UI, giving you independent control over which checks gate the merge queue.
+There are three ways to tell Merge Queue which status checks to wait on while testing a PR:
 
-**When to configure in Trunk:**
+1. **GitHub branch protection rules** (default) — Trunk infers required statuses from the protected branch's required status checks.
+2. **Trunk UI override** — configure required statuses directly in the Trunk UI.
+3. **`.trunk/trunk.yaml` override** — declare required statuses in `merge.required_statuses`.
+
+All three work regardless of which testing mode you chose (Draft PR or Push-Triggered).
+
+{% hint style="info" %}
+**This controls which checks gate merging while a PR is being tested in the queue. It does not control which PRs are admitted into the queue.**
+{% endhint %}
+
+**When to override the default:**
 
 * **Different checks for the queue** - Your branch protection requires checks that shouldn't gate the merge queue (e.g., code coverage reports, deployment previews)
 * **Stricter queue requirements** - You want the merge queue to require additional checks beyond what branch protection enforces
 * **Multiple queues** - Each queue can have its own set of required statuses
+* **No GitHub branch protection** - You don't use branch protection rules and need to tell Merge Queue what to wait on
 
-### How to configure
+### Configure in the Trunk UI
 
 1. Navigate to **Settings** > **Repositories** > your repository > **Merge Queue**
 2. Find the **Required Status Checks** section
@@ -232,6 +243,20 @@ By default, Trunk infers required status checks from your GitHub branch protecti
 {% hint style="info" %}
 When required statuses are configured in Trunk, only those statuses are required for the merge queue. When not configured, Trunk falls back to your GitHub branch protection required checks.
 {% endhint %}
+
+### Configure in `.trunk/trunk.yaml`
+
+Alternatively, declare required statuses in your `.trunk/trunk.yaml` file at the root of your repository:
+
+```yaml
+version: 0.1
+merge:
+  required_statuses:
+    - Unit Tests
+    - Integration Tests
+```
+
+The status check names must exactly match the CI job names that report status to GitHub.
 
 ***
 

--- a/merge-queue/administration/advanced-settings.md
+++ b/merge-queue/administration/advanced-settings.md
@@ -217,8 +217,8 @@ For example, assuming a timeout of 4 hours:
 There are three ways to tell Merge Queue which status checks to wait on while testing a PR:
 
 1. **GitHub branch protection rules** (default) — Trunk infers required statuses from the protected branch's required status checks.
-2. **Trunk UI override** — configure required statuses directly in the Trunk UI.
-3. **`.trunk/trunk.yaml` override** — declare required statuses in `merge.required_statuses`.
+2. **Trunk UI override** — Configure required statuses directly in the Trunk UI.
+3. **`.trunk/trunk.yaml` override** — Declare required statuses in `merge.required_statuses`.
 
 All three work regardless of which testing mode you chose (Draft PR or Push-Triggered).
 

--- a/merge-queue/getting-started/configure-branch-protection.md
+++ b/merge-queue/getting-started/configure-branch-protection.md
@@ -15,11 +15,11 @@ Before configuring branch protection:
 * [ ] CI runs on pull requests and reports status checks to GitHub
 * [ ] You have admin access to repository settings
 
-### How branch protection affects the queue
+### How Branch Protection Affects the Queue
 
 Trunk Merge Queue respects GitHub's branch protection rules and works with both Classic branch protection rules and Rulesets. Branch protection plays two distinct roles in how the queue operates:
 
-* **Admission into the queue** — Trunk doesn't admit a submitted PR for testing until GitHub considers it mergeable. Branch protection (required reviews, required status checks, conversation resolution, etc.) is what determines when GitHub flips a PR to mergeable, so it directly controls when a PR enters the queue.
+* **Admission into the queue** — Trunk doesn't admit a submitted PR for testing until GitHub considers it ready to merge. Branch protection (required reviews, required status checks, conversation resolution, etc.) is what determines when GitHub marks a PR as ready to merge, so it directly controls when a PR enters the queue.
 * **Required checks during testing (optional)** — By default, Trunk waits on the same required status checks defined in your branch protection rules while testing a PR in the queue. You can override this with the Trunk UI or `.trunk/trunk.yaml` if you want a different set of checks required during queue testing. See [Required Status Checks](../administration/advanced-settings.md#required-status-checks).
 
 The configurations on this page (push restrictions for the `trunk-io` bot, and excluding `trunk-temp/*` and `trunk-merge/*` from protection) ensure branch protection doesn't *block* Trunk from doing its job. They don't change either of the roles above.

--- a/merge-queue/getting-started/configure-branch-protection.md
+++ b/merge-queue/getting-started/configure-branch-protection.md
@@ -60,8 +60,7 @@ When a pull request enters the queue, Trunk creates a `trunk-merge/*` branch and
 
 **Requirements:**
 
-* Configure push-triggered workflows in your CI provider for `trunk-merge/**` branches
-* Define required status checks in your `.trunk/trunk.yaml` [configuration file](configure-ci-status-checks.md#if-using-draft-pr-mode-default)
+* Configure push-triggered workflows in your CI provider for `trunk-merge/**` branches (see [Configure CI status checks](configure-ci-status-checks.md#if-using-push-triggered-mode))
 
 **To enable:** Go to **Settings** > **Repositories** > repository > **Merge Queue** > toggle **off** **Trunk Draft PR Creation**.
 

--- a/merge-queue/getting-started/configure-branch-protection.md
+++ b/merge-queue/getting-started/configure-branch-protection.md
@@ -20,7 +20,7 @@ Before configuring branch protection:
 Trunk Merge Queue respects GitHub's branch protection rules and works with both Classic branch protection rules and Rulesets. Branch protection plays two distinct roles in how the queue operates:
 
 * **Admission into the queue** — Trunk doesn't admit a submitted PR for testing until GitHub considers it mergeable. Branch protection (required reviews, required status checks, conversation resolution, etc.) is what determines when GitHub flips a PR to mergeable, so it directly controls when a PR enters the queue.
-* **Gating during testing (optional)** — By default, Trunk waits on the same required status checks defined in your branch protection rules while testing a PR. You can override this with the Trunk UI or `.trunk/trunk.yaml` if you want a different set of checks to gate the queue. See [Required Status Checks](../administration/advanced-settings.md#required-status-checks).
+* **Required checks during testing (optional)** — By default, Trunk waits on the same required status checks defined in your branch protection rules while testing a PR in the queue. You can override this with the Trunk UI or `.trunk/trunk.yaml` if you want a different set of checks required during queue testing. See [Required Status Checks](../administration/advanced-settings.md#required-status-checks).
 
 The configurations on this page (push restrictions for the `trunk-io` bot, and excluding `trunk-temp/*` and `trunk-merge/*` from protection) ensure branch protection doesn't *block* Trunk from doing its job. They don't change either of the roles above.
 

--- a/merge-queue/getting-started/configure-branch-protection.md
+++ b/merge-queue/getting-started/configure-branch-protection.md
@@ -1,7 +1,7 @@
 ---
 description: >-
-  Configure GitHub branch protection rules so Trunk Merge Queue can create
-  test branches and merge PRs into your protected branch.
+  Set up GitHub branch protection so Trunk Merge Queue can admit, test, and
+  merge pull requests through your protected branch.
 ---
 
 # Configure branch protection
@@ -15,9 +15,14 @@ Before configuring branch protection:
 * [ ] CI runs on pull requests and reports status checks to GitHub
 * [ ] You have admin access to repository settings
 
-### How Trunk Merge Queue works
+### How branch protection affects the queue
 
-Trunk Merge Queue respects GitHub's branch protection rules and works with both Classic branch protection rules and Rulesets. Since Merge Queue ultimately merges pull requests through GitHub, any protection rules on your target branch (like required code reviews or status checks) will still apply.
+Trunk Merge Queue respects GitHub's branch protection rules and works with both Classic branch protection rules and Rulesets. Branch protection plays two distinct roles in how the queue operates:
+
+* **Admission into the queue** — Trunk doesn't admit a submitted PR for testing until GitHub considers it mergeable. Branch protection (required reviews, required status checks, conversation resolution, etc.) is what determines when GitHub flips a PR to mergeable, so it directly controls when a PR enters the queue.
+* **Gating during testing (optional)** — By default, Trunk waits on the same required status checks defined in your branch protection rules while testing a PR. You can override this with the Trunk UI or `.trunk/trunk.yaml` if you want a different set of checks to gate the queue. See [Required Status Checks](../administration/advanced-settings.md#required-status-checks).
+
+The configurations on this page (push restrictions for the `trunk-io` bot, and excluding `trunk-temp/*` and `trunk-merge/*` from protection) ensure branch protection doesn't *block* Trunk from doing its job. They don't change either of the roles above.
 
 ### Choose your testing approach
 

--- a/merge-queue/getting-started/configure-ci-status-checks.md
+++ b/merge-queue/getting-started/configure-ci-status-checks.md
@@ -61,17 +61,17 @@ jobs:
 
 **For other CI providers:** Configure workflows triggered by pushes to branches matching `trunk-merge/**`.
 
-### Choosing which checks gate the queue <a href="#choosing-which-checks-gate-the-queue" id="choosing-which-checks-gate-the-queue"></a>
+### Required checks during queue testing <a href="#required-checks-during-queue-testing" id="required-checks-during-queue-testing"></a>
 
-By default, Merge Queue waits on the same required status checks defined in your GitHub branch protection rules before merging a PR. If you want a different set of checks to gate the queue — for example, because you don't use GitHub branch protection, or because the queue should require different checks than PR review — you can override that in the Trunk UI or in `.trunk/trunk.yaml` (`merge.required_statuses`). Both overrides work in either testing mode.
+By default, Merge Queue waits on the same required status checks defined in your GitHub branch protection rules while testing a PR. If you want a different set of checks required during queue testing — for example, because you don't use GitHub branch protection, or because the queue should require different checks than PR review — you can override that in the Trunk UI or in `.trunk/trunk.yaml` (`merge.required_statuses`). Both overrides work in either testing mode.
 
 {% hint style="info" %}
-**This controls which checks gate merging while a PR is being tested in the queue. It does not control which PRs are admitted into the queue.**
+**These checks are what Merge Queue waits on while a PR is already in the queue and testing. They do not control which PRs are admitted into the queue.**
 {% endhint %}
 
 PR admission is governed separately: Trunk waits until GitHub considers the PR mergeable (driven by your [branch protection rules](configure-branch-protection.md#how-branch-protection-affects-the-queue)) before testing begins. If your queue is running in [parallel mode](../optimizations/parallel-queues/README.md), Trunk additionally waits for the PR's [impacted targets](../optimizations/parallel-queues/README.md#what-are-impacted-targets) to be uploaded.
 
-See [Required Status Checks](../administration/advanced-settings.md#required-status-checks) for the full set of gating options.
+See [Required Status Checks](../administration/advanced-settings.md#required-status-checks) for the full set of options.
 
 ### Next Steps
 

--- a/merge-queue/getting-started/configure-ci-status-checks.md
+++ b/merge-queue/getting-started/configure-ci-status-checks.md
@@ -1,33 +1,27 @@
 ---
 description: >-
-  Configure your CI provider to run required status checks on Trunk Merge
-  Queue branches.
+  Make sure your CI runs whenever Trunk Merge Queue tests a pull request.
 ---
 
 # Configure CI status checks
 
-### If using Draft PR mode (Default) <a href="#if-using-draft-pr-mode-default" id="if-using-draft-pr-mode-default"></a>
+This page covers how to make sure your CI checks run on the branches Trunk Merge Queue creates while testing a pull request. What you need to do depends on the testing mode you selected in [Configure branch protection](configure-branch-protection.md):
+
+* **Draft PR mode (default)** — no additional CI configuration is required.
+* **Push-Triggered mode** — you need to add a CI workflow that triggers on pushes to `trunk-merge/**`.
+
+### If using Draft PR mode (default) <a href="#if-using-draft-pr-mode-default" id="if-using-draft-pr-mode-default"></a>
 
 Your existing pull request-triggered CI workflows will automatically run when Trunk creates draft pull requests to test changes. **No additional configuration is required.**
 
-Trunk will wait for the same required status checks configured in your branch protection rules (either via Classic rules or Rulesets) before merging.
-
-{% hint style="info" %}
-You can also configure required status checks directly in the Trunk UI instead of relying on GitHub branch protection. See [Required Status Checks](../administration/advanced-settings.md#required-status-checks) in the settings documentation.
-{% endhint %}
-
-See GitHub's documentation for configuring required status checks:
+See GitHub's documentation for configuring required status checks on your protected branch:
 
 * [Classic branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging)
 * [Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
 
-**You're done!** Skip to the Verification section below.
+**You're done!** Skip to the [Verification](test-your-setup.md) section.
 
 ### If using Push-Triggered mode <a href="#if-using-push-triggered-mode" id="if-using-push-triggered-mode"></a>
-
-You need to complete two additional steps:
-
-**Step 1: Configure Push-Triggered CI Workflows**
 
 Set up your CI provider to run status checks whenever Trunk pushes to `trunk-merge/*` branches.
 
@@ -50,7 +44,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      
+
       - name: Run tests
         run: npm test  # Your actual test commands
 
@@ -60,28 +54,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      
+
       - name: Run integration tests
         run: npm run test:integration  # Your actual test commands
 ```
 
 **For other CI providers:** Configure workflows triggered by pushes to branches matching `trunk-merge/**`.
 
-**Step 2: Define Required Status Checks in .trunk/trunk.yaml**
+### Choosing which checks gate the queue <a href="#choosing-which-checks-gate-the-queue" id="choosing-which-checks-gate-the-queue"></a>
 
-Create or edit your `trunk.yaml` file in a directory named `.trunk` at the root of your repository (so, `.trunk/trunk.yaml`) to specify which status checks Trunk should wait for before merging:
+By default, Merge Queue waits on the same required status checks defined in your GitHub branch protection rules before merging a PR. If you want a different set of checks to gate the queue — for example, because you don't use GitHub branch protection, or because the queue should require different checks than PR review — you can override that in the Trunk UI or in `.trunk/trunk.yaml` (`merge.required_statuses`). Both overrides work in either testing mode.
 
-```yaml
-version: 0.1
-merge:
-  required_statuses:
-    - Unit Tests
-    - Integration Tests
-```
+{% hint style="info" %}
+**This controls which checks gate merging while a PR is being tested in the queue. It does not control which PRs are admitted into the queue.**
+{% endhint %}
 
-**Important:** The status check names in `.trunk/trunk.yaml` must exactly match the job names from your CI workflows.
-
-
+See [Required Status Checks](../administration/advanced-settings.md#required-status-checks) for the full set of options.
 
 ### Next Steps
 

--- a/merge-queue/getting-started/configure-ci-status-checks.md
+++ b/merge-queue/getting-started/configure-ci-status-checks.md
@@ -23,7 +23,7 @@ See GitHub's documentation for configuring required status checks on your protec
 
 ### If using Push-Triggered mode <a href="#if-using-push-triggered-mode" id="if-using-push-triggered-mode"></a>
 
-Set up your CI provider to run status checks whenever Trunk pushes to `trunk-merge/*` branches.
+Set up your CI provider to run status checks whenever Trunk pushes to `trunk-merge/**` branches.
 
 **Example for GitHub Actions:**
 
@@ -61,7 +61,7 @@ jobs:
 
 **For other CI providers:** Configure workflows triggered by pushes to branches matching `trunk-merge/**`.
 
-### Required checks during queue testing <a href="#required-checks-during-queue-testing" id="required-checks-during-queue-testing"></a>
+### Required Checks During Queue Testing <a href="#required-checks-during-queue-testing" id="required-checks-during-queue-testing"></a>
 
 By default, Merge Queue waits on the same required status checks defined in your GitHub branch protection rules while testing a PR. If you want a different set of checks required during queue testing — for example, because you don't use GitHub branch protection, or because the queue should require different checks than PR review — you can override that in the Trunk UI or in `.trunk/trunk.yaml` (`merge.required_statuses`). Both overrides work in either testing mode.
 
@@ -69,7 +69,7 @@ By default, Merge Queue waits on the same required status checks defined in your
 **These checks are what Merge Queue waits on while a PR is already in the queue and testing. They do not control which PRs are admitted into the queue.**
 {% endhint %}
 
-PR admission is governed separately: Trunk waits until GitHub considers the PR mergeable (driven by your [branch protection rules](configure-branch-protection.md#how-branch-protection-affects-the-queue)) before testing begins. If your queue is running in [parallel mode](../optimizations/parallel-queues/README.md), Trunk additionally waits for the PR's [impacted targets](../optimizations/parallel-queues/README.md#what-are-impacted-targets) to be uploaded.
+PR admission is governed separately: Trunk waits until GitHub considers the PR ready to merge (driven by your [branch protection rules](configure-branch-protection.md#how-branch-protection-affects-the-queue)) before testing begins. If your queue is running in [parallel mode](../optimizations/parallel-queues/README.md), Trunk additionally waits for the [impacted targets](../optimizations/parallel-queues/README.md#what-are-impacted-targets) of that PR to be uploaded.
 
 See [Required Status Checks](../administration/advanced-settings.md#required-status-checks) for the full set of options.
 

--- a/merge-queue/getting-started/configure-ci-status-checks.md
+++ b/merge-queue/getting-started/configure-ci-status-checks.md
@@ -69,7 +69,9 @@ By default, Merge Queue waits on the same required status checks defined in your
 **This controls which checks gate merging while a PR is being tested in the queue. It does not control which PRs are admitted into the queue.**
 {% endhint %}
 
-See [Required Status Checks](../administration/advanced-settings.md#required-status-checks) for the full set of options.
+PR admission is governed separately: Trunk waits until GitHub considers the PR mergeable (driven by your [branch protection rules](configure-branch-protection.md#how-branch-protection-affects-the-queue)) before testing begins. If your queue is running in [parallel mode](../optimizations/parallel-queues/README.md), Trunk additionally waits for the PR's [impacted targets](../optimizations/parallel-queues/README.md#what-are-impacted-targets) to be uploaded.
+
+See [Required Status Checks](../administration/advanced-settings.md#required-status-checks) for the full set of gating options.
 
 ### Next Steps
 


### PR DESCRIPTION
## Summary
Restructured and clarified documentation for configuring CI status checks with Trunk Merge Queue, with a focus on making the distinction between testing modes clearer and simplifying the configuration steps.

## Key Changes

- **Reorganized getting-started guide**: Moved the overview of both testing modes to the top of the page, allowing users to quickly understand which path applies to them
- **Simplified Push-Triggered mode instructions**: Removed the "Step 1" and "Step 2" numbering and restructured the content to flow more naturally
- **Consolidated required status checks documentation**: Moved the `.trunk/trunk.yaml` configuration example from the getting-started guide to the advanced-settings reference page where it belongs
- **Clarified the purpose of required status checks**: Added explicit callout that required status checks control which checks gate merging during queue testing, not which PRs are admitted to the queue
- **Expanded advanced-settings documentation**: Added comprehensive explanation of the three ways to configure required statuses (GitHub branch protection, Trunk UI, and `.trunk/trunk.yaml`), with guidance on when to use each approach
- **Updated cross-references**: Changed links to point to the appropriate sections (e.g., linking to test-your-setup.md for verification)
- **Minor formatting fixes**: Removed trailing whitespace in code examples

## Notable Details

The changes maintain all technical accuracy while improving information architecture. The core functionality remains unchanged; this is purely a documentation improvement to help users understand the configuration options more clearly.

https://claude.ai/code/session_01FQDDuxLgk8U5mmvN5pRVJR