### PR TITLE
docs(flaky-tests): note admin-only requirement for AI investigations setting

### DIFF
--- a/flaky-tests/autofix-flaky-tests.md
+++ b/flaky-tests/autofix-flaky-tests.md
@@ -7,7 +7,7 @@ Trunk can automatically investigate flaky tests in your codebase and raise fix p
 To use the Autofix Flaky Tests feature, you'll need:
 
 1. Beta access via waitlist (reach out to us on [Slack](https://slack.trunk.io))
-2. The "Investigate Flaky Tests" setting enabled in your workspace
+2. The "Investigate Flaky Tests" setting enabled in your workspace by a workspace admin
 
 <figure><img src="../.gitbook/assets/investigate-flaky-tests-setting.png" alt="Setting to enable Flaky Test investigation"><figcaption></figcaption></figure>
 


### PR DESCRIPTION
## Summary

- Updates `autofix-flaky-tests.md` prerequisites to clarify that enabling the "Investigate Flaky Tests" setting requires workspace admin rights

## Related

- trunk-io/trunk2#3728 (shipped in v161)

## Test plan

- [ ] Verify the updated prerequisite text renders correctly on docs.trunk.io

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_012hhLQAdU8wVEpePQd1NGbi)_