### PR TITLE
Clarify trunk sudo docs

### DIFF
--- a/setup-and-administration/trunk-sudo-app.md
+++ b/setup-and-administration/trunk-sudo-app.md
@@ -72,7 +72,11 @@ If you're using classic branch protection rules, navigate to **Settings → Bran
 
 ### Verify your setup
 
-The Trunk Merge Queue settings page includes a live checklist that validates every piece of the Trunk Sudo configuration end-to-end. **This checklist is the source of truth for whether your setup is correct** — if the checklist is green, the app is ready to merge.
+The settings page for each Trunk Merge Queue includes a live checklist that validates every piece of the Trunk Sudo configuration end-to-end. **This checklist is the source of truth for whether your setup is correct** — if the checklist is green, the app is ready to merge.
+
+{% hint style="info" %}
+To see this checklist, go to a merge queue belonging to the repo you are setting up Trunk Sudo in, then click on the settings tab.
+{% endhint %}
 
 <figure><img src="../.gitbook/assets/trunk-sudo-setup-checklist.png" alt="Trunk Sudo setup checklist in the Merge Queue settings page"><figcaption>Trunk Sudo setup checklist in the Merge Queue settings page when everything is configured properly.</figcaption></figure>
 

--- a/setup-and-administration/trunk-sudo-app.md
+++ b/setup-and-administration/trunk-sudo-app.md
@@ -75,7 +75,7 @@ If you're using classic branch protection rules, navigate to **Settings → Bran
 The settings page for each Trunk Merge Queue includes a live checklist that validates every piece of the Trunk Sudo configuration end-to-end. **This checklist is the source of truth for whether your setup is correct** — if the checklist is green, the app is ready to merge.
 
 {% hint style="info" %}
-To see this checklist, go to a merge queue belonging to the repo you are setting up Trunk Sudo in, then click on the settings tab.
+To see this checklist, go to a merge queue in the repo where you are setting up Trunk Sudo, then click the **Settings** tab.
 {% endhint %}
 
 <figure><img src="../.gitbook/assets/trunk-sudo-setup-checklist.png" alt="Trunk Sudo setup checklist in the Merge Queue settings page"><figcaption>Trunk Sudo setup checklist in the Merge Queue settings page when everything is configured properly.</figcaption></figure>


### PR DESCRIPTION
Wording clarification in response to https://trunk-io.slack.com/archives/C0338C8U27M/p1778073663084109?thread_ts=1777990435.190639&cid=C0338C8U27M

>hey sorry for the delay, we have an onsite this week. I just set this up (I think) but this section is a little unclear: https://docs.trunk.io/setup-and-administration/trunk-sudo-app#verify-your-setup
I think it might be telling me to go to https://app.trunk.io/faire/settings/repositories but when I do that I get an error message (after a long delay) :slightly_smiling_face: