### PR TITLE
Specify API size limit with some guidance in merge public API

### DIFF
--- a/merge-queue/reference/merge.md
+++ b/merge-queue/reference/merge.md
@@ -140,13 +140,13 @@ The response includes the queue state (`RUNNING`, `PAUSED`, `DRAINING`, or `SWIT
 [OpenAPI trunk-api](https://static.trunk.io/docs/openapi.json)
 {% endopenapi-operation %}
 
-{% hint style="warning" %}
-Large monorepos can produce target lists that exceed the 20 MiB request body limit. If you hit this limit, send `"ALL"` as the impacted targets value to mark the PR as impacting every target.
-{% endhint %}
-
 {% openapi-operation spec="trunk-api" path="/setImpactedTargets" method="post" %}
 [OpenAPI trunk-api](https://static.trunk.io/docs/openapi.json)
 {% endopenapi-operation %}
+
+{% hint style="warning" %}
+Large monorepos can produce target lists that exceed the 20 MiB request body limit. If you hit this limit, send `"ALL"` as the `impactedTargets` value to mark the PR as impacting every target.
+{% endhint %}
 
 {% openapi-operation spec="trunk-api" path="/submitPullRequest" method="post" %}
 [OpenAPI trunk-api](https://static.trunk.io/docs/openapi.json)

--- a/merge-queue/reference/merge.md
+++ b/merge-queue/reference/merge.md
@@ -38,6 +38,8 @@ All requests must be [authenticated](../../setup-and-administration/apis/#authen
 
 ## Request format
 
+Request bodies must not exceed 20 MiB.
+
 Most endpoints accept a JSON request body with these common fields:
 
 ```json
@@ -137,6 +139,10 @@ The response includes the queue state (`RUNNING`, `PAUSED`, `DRAINING`, or `SWIT
 {% openapi-operation spec="trunk-api" path="/restartTestsOnPullRequest" method="post" %}
 [OpenAPI trunk-api](https://static.trunk.io/docs/openapi.json)
 {% endopenapi-operation %}
+
+{% hint style="warning" %}
+Large monorepos can produce target lists that exceed the 20 MiB request body limit. If you hit this limit, send `"ALL"` as the impacted targets value to mark the PR as impacting every target.
+{% endhint %}
 
 {% openapi-operation spec="trunk-api" path="/setImpactedTargets" method="post" %}
 [OpenAPI trunk-api](https://static.trunk.io/docs/openapi.json)


### PR DESCRIPTION
Simple enough

Note - the new API size limit is getting set in https://github.com/trunk-io/trunk/pull/31993