### PR TITLE
[ready to merge] docs(merge-queue): document Celebration setting in Chrome Extension

### DIFF
--- a/merge-queue/chrome-extension.md
+++ b/merge-queue/chrome-extension.md
@@ -62,7 +62,7 @@ The extension does **not** ask you for credentials, API tokens, or a separate pa
 
 ### Extension settings
 
-Click the Trunk extension icon and open **Options** (or right-click the icon and choose **Manage extension → Options**) to access the extension settings page.
+Click the Trunk extension icon and open **Options** (or right-click the icon and choose **Options**) to access the extension settings page.
 
 | Setting | Description | Default |
 |---|---|---|

--- a/merge-queue/chrome-extension.md
+++ b/merge-queue/chrome-extension.md
@@ -60,6 +60,16 @@ The extension does **not** ask you for credentials, API tokens, or a separate pa
 * **Scoped to GitHub PR pages.** The content script runs on `github.com` pull request URLs so it can render the overlay; it does not read or transmit page contents beyond the repository and PR identifiers needed to query the Trunk API.
 * **Same transport guarantees as the rest of Trunk.** All extension traffic to Trunk uses TLS, and your data is handled per the [Trunk Security policy](../setup-and-administration/security.md).
 
+### Extension settings
+
+Click the Trunk extension icon and open **Options** (or right-click the icon and choose **Manage extension → Options**) to access the extension settings page.
+
+| Setting | Description | Default |
+|---|---|---|
+| **Celebration** | When enabled, a confetti burst plays each time you add a pull request to the merge queue. | Off |
+
+The celebration effect respects your operating system's reduced motion preference. If you have **Reduce motion** enabled in your system accessibility settings, no animation plays regardless of this toggle.
+
 ### Frequently asked questions
 
 <details open>


### PR DESCRIPTION
## Summary
Documents the new Celebration (confetti) toggle in the Chrome Extension settings. The effect is off by default and fires on add-to-queue actions. Respects reduced motion preference.

## Source
- trunk2 PR #3916: https://github.com/trunk-io/trunk2/pull/3916

## Test plan
- [ ] Preview in GitBook

---
_Generated by [Claude Code](https://claude.ai/code/session_015wK7XugwMAnnDHptZPNfEF)_