### PR TITLE
docs(chrome-extension): hide Celebration setting behind an easter-egg disclosure

### DIFF
--- a/merge-queue/chrome-extension.md
+++ b/merge-queue/chrome-extension.md
@@ -60,20 +60,6 @@ The extension does **not** ask you for credentials, API tokens, or a separate pa
 * **Scoped to GitHub PR pages.** The content script runs on `github.com` pull request URLs so it can render the overlay; it does not read or transmit page contents beyond the repository and PR identifiers needed to query the Trunk API.
 * **Same transport guarantees as the rest of Trunk.** All extension traffic to Trunk uses TLS, and your data is handled per the [Trunk Security policy](../setup-and-administration/security.md).
 
-<details>
-
-<summary><strong>Have you turned on Celebration Mode?</strong></summary>
-
-Click the Trunk extension icon and open **Options** (or right-click the icon and choose **Options**) to access the extension settings page.
-
-| Setting | Description | Default |
-|---|---|---|
-| **Celebration** | When enabled, a confetti burst plays each time you add a pull request to the merge queue. | Off |
-
-The celebration effect respects your operating system's reduced motion preference. If you have **Reduce motion** enabled in your system accessibility settings, no animation plays regardless of this toggle.
-
-</details>
-
 ### Frequently asked questions
 
 <details open>
@@ -105,5 +91,19 @@ The extension targets Chrome. Chromium-based browsers (Edge, Brave, Arc) general
 <summary><strong>How does the extension differ from the `/trunk merge` comment?</strong></summary>
 
 Both go through the same Trunk Merge Queue backend. The extension is a faster, in-page surface for the same actions and adds live status without polling the PR comments.
+
+</details>
+
+<details>
+
+<summary><strong>How do I enable Celebration Mode?</strong></summary>
+
+Click the Trunk extension icon and open **Options** (or right-click the icon and choose **Options**) to access the extension settings page.
+
+| Setting | Description | Default |
+|---|---|---|
+| **Celebration** | When enabled, a confetti burst plays each time you add a pull request to the merge queue. | Off |
+
+The celebration effect respects your operating system's reduced motion preference. If you have **Reduce motion** enabled in your system accessibility settings, no animation plays regardless of this toggle.
 
 </details>

--- a/merge-queue/chrome-extension.md
+++ b/merge-queue/chrome-extension.md
@@ -60,7 +60,9 @@ The extension does **not** ask you for credentials, API tokens, or a separate pa
 * **Scoped to GitHub PR pages.** The content script runs on `github.com` pull request URLs so it can render the overlay; it does not read or transmit page contents beyond the repository and PR identifiers needed to query the Trunk API.
 * **Same transport guarantees as the rest of Trunk.** All extension traffic to Trunk uses TLS, and your data is handled per the [Trunk Security policy](../setup-and-administration/security.md).
 
-### Extension settings
+<details>
+
+<summary><strong>Have you turned on Celebration Mode?</strong></summary>
 
 Click the Trunk extension icon and open **Options** (or right-click the icon and choose **Options**) to access the extension settings page.
 
@@ -69,6 +71,8 @@ Click the Trunk extension icon and open **Options** (or right-click the icon and
 | **Celebration** | When enabled, a confetti burst plays each time you add a pull request to the merge queue. | Off |
 
 The celebration effect respects your operating system's reduced motion preference. If you have **Reduce motion** enabled in your system accessibility settings, no animation plays regardless of this toggle.
+
+</details>
 
 ### Frequently asked questions
 


### PR DESCRIPTION
## Summary

- Wraps the Celebration extension setting (the opt-in confetti burst) in a closed `<details>` block
- Summary text reads "Have you turned on Celebration Mode?" so the disclosure functions as a discovery prompt rather than a labeled section
- Drops the explicit `### Extension settings` heading since the section was a single easter-egg setting

## Context

Follow-up to #626 (Celebration setting docs). Treating it as a hidden discovery on the extension page makes the reveal more fun for readers who poke around, rather than calling it out under a regular heading.

## Test plan

- [ ] Verify the `<details>` renders as a closed disclosure in GitBook preview, with "Have you turned on Celebration Mode?" as the bold summary
- [ ] Click to expand and confirm the access instructions, settings table, and reduced-motion note all render correctly inside
- [ ] Confirm the next section (`### Frequently asked questions`) still flows correctly after the disclosure