### PR TITLE
[feature not live] docs(merge-queue): add Testing Duration chart to metrics page

### DIFF
--- a/merge-queue/administration/metrics.md
+++ b/merge-queue/administration/metrics.md
@@ -95,19 +95,19 @@ Understanding the amount of time a pull request spends in the queue is important
 
 The time in queue can be displayed as different statistical measures. You can show or hide them by using the **+ Add** button.
 
-| Measure | Explanation                                         |
-| ------- | --------------------------------------------------- |
-| Average | Average of all time in queue during the time bucket |
-| Minimum | The shortest time in queue in the time bucket.      |
-| Maximum | The longest time in queue in the time bucket.       |
-| Sum     | The total of all time in queue added together.      |
-| P50     | The value below 50% of the time in queue falls.     |
-| P95     | The value below 95% of the time in queue falls.     |
-| P99     | The value below 99% of the time in queue falls.     |
+| Measure | Explanation |
+| ------- | ----------- |
+| Average | Average time in queue during the time bucket |
+| Minimum | The shortest time in queue in the time bucket |
+| Maximum | The longest time in queue in the time bucket |
+| Sum | The total of all time in queue added together |
+| P50 | The value below which 50% of times in queue fall |
+| P95 | The value below which 95% of times in queue fall |
+| P99 | The value below which 99% of times in queue fall |
 
 ### Testing duration
 
-Testing duration shows how long each PR spends in the TESTING state within the Merge Queue, measured from when testing begins to when the cycle reaches its final state. Unlike the Conclusion count and Time in queue charts, testing duration uses separate data bucketing. Hovering over a data point will not highlight the corresponding point on the other charts.
+Testing duration shows how long each PR spends in the TESTING state within the Merge Queue, measured from when testing begins to when the testing cycle reaches its final state. Unlike the Conclusion count and Time in queue charts, testing duration uses separate data bucketing. Hovering over a data point will not highlight the corresponding point on the other charts.
 
 This is distinct from [Time in queue](#time-in-queue), which measures total time from queue entry to exit. A PR that waits before testing starts will have a longer time in queue but the same testing duration. Use this chart to understand CI performance specifically, separate from queue wait time.
 
@@ -126,8 +126,8 @@ Two dropdowns let you narrow the data shown in the chart.
 | All Outcomes | Include all testing cycles (default) |
 | Passed | Cycles where tests passed |
 | Failed | Cycles where tests failed |
-| Interrupted | Cycles interrupted before completion |
-| Cancelled | Cycles cancelled before tests ran to completion |
+| Interrupted | Test runs cut short by a restart, preempt, or base-branch change (the cycle may continue with a new run) |
+| Cancelled | Cycles cancelled mid-test (the cycle ends without a passing or failing result) |
 
 **Cycle ended in** filters by how the PR's overall merge cycle resolved:
 

--- a/merge-queue/administration/metrics.md
+++ b/merge-queue/administration/metrics.md
@@ -105,6 +105,48 @@ The time in queue can be displayed as different statistical measures. You can sh
 | P95     | The value below 95% of the time in queue falls.     |
 | P99     | The value below 99% of the time in queue falls.     |
 
+### Testing duration
+
+Testing duration shows how long each PR spends in the TESTING state within the Merge Queue, measured from when testing begins to when the cycle reaches its final state. Unlike the Conclusion count and Time in queue charts, testing duration uses separate data bucketing — hovering over a data point will not highlight the corresponding point on the other charts.
+
+Each data point represents one TESTING-to-final-state transition. A single PR can contribute multiple data points if its testing cycle restarted.
+
+The stat measures match those on the Time in queue chart:
+
+| Measure | Explanation |
+| ------- | ----------- |
+| Average | Average testing duration during the time bucket |
+| Minimum | The shortest testing duration in the time bucket |
+| Maximum | The longest testing duration in the time bucket |
+| Sum | The total of all testing durations added together |
+| P50 | The value below which 50% of testing durations fall |
+| P95 | The value below which 95% of testing durations fall |
+| P99 | The value below which 99% of testing durations fall |
+
+#### Filters
+
+Two dropdowns let you narrow the data shown in the chart:
+
+**Outcome** — filter by how each testing cycle ended:
+
+| Value | Meaning |
+| ----- | ------- |
+| All Outcomes | Include all testing cycles (default) |
+| Passed | Cycles where tests passed |
+| Failed | Cycles where tests failed |
+| Interrupted | Cycles interrupted before completion |
+| Cancelled | Cycles cancelled before tests ran to completion |
+
+**Cycle ended in** — filter by how the PR's overall merge cycle resolved:
+
+| Value | Meaning |
+| ----- | ------- |
+| All | Include all PR cycles (default) |
+| Merged | PR was ultimately merged |
+| Failed | PR ultimately failed out of the queue |
+| Cancelled | PR was cancelled |
+| In Flight | PR cycle is still in progress |
+
 ### Drill down into metrics
 
 From the **Conclusion count** and **Time in queue** charts, you can drill into any point or window on the graph to see the exact pull requests that made up those numbers.

--- a/merge-queue/administration/metrics.md
+++ b/merge-queue/administration/metrics.md
@@ -107,9 +107,41 @@ The time in queue can be displayed as different statistical measures. You can sh
 
 ### Testing duration
 
-Testing duration shows how long each PR spends in the TESTING state within the Merge Queue, measured from when testing begins to when the cycle reaches its final state. Unlike the Conclusion count and Time in queue charts, testing duration uses separate data bucketing — hovering over a data point will not highlight the corresponding point on the other charts.
+Testing duration shows how long each PR spends in the TESTING state within the Merge Queue, measured from when testing begins to when the cycle reaches its final state. Unlike the Conclusion count and Time in queue charts, testing duration uses separate data bucketing. Hovering over a data point will not highlight the corresponding point on the other charts.
 
+This is distinct from [Time in queue](#time-in-queue), which measures total time from queue entry to exit. A PR that waits before testing starts will have a longer time in queue but the same testing duration. Use this chart to understand CI performance specifically, separate from queue wait time.
+
+{% hint style="info" %}
 Each data point represents one TESTING-to-final-state transition. A single PR can contribute multiple data points if its testing cycle restarted.
+{% endhint %}
+
+#### Filters
+
+Two dropdowns let you narrow the data shown in the chart.
+
+**Outcome** filters by how each testing cycle ended:
+
+| Value | Meaning |
+| ----- | ------- |
+| All Outcomes | Include all testing cycles (default) |
+| Passed | Cycles where tests passed |
+| Failed | Cycles where tests failed |
+| Interrupted | Cycles interrupted before completion |
+| Cancelled | Cycles cancelled before tests ran to completion |
+
+**Cycle ended in** filters by how the PR's overall merge cycle resolved:
+
+| Value | Meaning |
+| ----- | ------- |
+| All | Include all PR cycles (default) |
+| Merged | PR was ultimately merged |
+| Failed | PR ultimately failed out of the queue |
+| Cancelled | PR was cancelled |
+| In Flight | PR cycle is still in progress |
+
+Combine the two to isolate specific patterns. For example, set **Outcome** to Passed and **Cycle ended in** to Merged to see testing durations for PRs that ultimately merged, giving you a clean baseline for CI speed without noise from canceled or failed runs.
+
+#### Statistical measures
 
 The stat measures match those on the Time in queue chart:
 
@@ -122,30 +154,6 @@ The stat measures match those on the Time in queue chart:
 | P50 | The value below which 50% of testing durations fall |
 | P95 | The value below which 95% of testing durations fall |
 | P99 | The value below which 99% of testing durations fall |
-
-#### Filters
-
-Two dropdowns let you narrow the data shown in the chart:
-
-**Outcome** — filter by how each testing cycle ended:
-
-| Value | Meaning |
-| ----- | ------- |
-| All Outcomes | Include all testing cycles (default) |
-| Passed | Cycles where tests passed |
-| Failed | Cycles where tests failed |
-| Interrupted | Cycles interrupted before completion |
-| Cancelled | Cycles cancelled before tests ran to completion |
-
-**Cycle ended in** — filter by how the PR's overall merge cycle resolved:
-
-| Value | Meaning |
-| ----- | ------- |
-| All | Include all PR cycles (default) |
-| Merged | PR was ultimately merged |
-| Failed | PR ultimately failed out of the queue |
-| Cancelled | PR was cancelled |
-| In Flight | PR cycle is still in progress |
 
 ### Drill down into metrics
 


### PR DESCRIPTION
## Summary
- Documents the new Testing Duration chart in the Merge Queue Health tab
- Covers the Outcome and Cycle Ended In filter dropdowns
- Notes separate bucketing behavior (no cross-chart hover sync)
- Adds stat measures table (Avg, Min, Max, Sum, P50, P95, P99)

## Source
- trunk2 PR: https://github.com/trunk-io/trunk2/pull/3919

## Test plan
- [ ] Preview in GitBook

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSsyg6HAXtEXjvpbfXj3Nc)_