### PR TITLE
[ready to merge] docs(setup): document ability for users to leave an organization

### DIFF
--- a/setup-and-administration/managing-your-organization.md
+++ b/setup-and-administration/managing-your-organization.md
@@ -56,3 +56,15 @@ You can enable team domains under **Settings > Organization > Team > Domains** a
 {% hint style="success" %}
 Trunk also supports SSO login. If you wish to use SSO, please contact us at support@trunk.io.
 {% endhint %}
+
+***
+
+## Leaving an Organization
+
+You can remove yourself from an organization at any time by navigating to **Settings** > **Organization** > **General** and clicking **Leave Organization**.
+
+A confirmation dialog will ask you to confirm. Once you leave, you lose access to the organization's settings, repositories, and test data. Another member can invite you back if needed.
+
+**If you are an admin**, the **Leave Organization** button appears in the **Danger Zone** section at the bottom of the General settings page alongside the Delete Organization option.
+
+**If you are not an admin**, the Leave Organization option appears as a standalone card outside the Danger Zone section.

--- a/setup-and-administration/managing-your-organization.md
+++ b/setup-and-administration/managing-your-organization.md
@@ -63,8 +63,8 @@ Trunk also supports SSO login. If you wish to use SSO, please contact us at supp
 
 You can remove yourself from an organization at any time by navigating to **Settings** > **Organization** > **General** and clicking **Leave Organization**.
 
-A confirmation dialog will ask you to confirm. Once you leave, you lose access to the organization's settings, repositories, and test data. Another member can invite you back if needed.
+A confirmation dialog will appear. Once you leave, you lose access to the organization's settings, repositories, and test data. Another member can invite you back if needed.
 
-**If you are an admin**, the **Leave Organization** button appears in the **Danger Zone** section at the bottom of the General settings page alongside the Delete Organization option.
+**If you are an admin**, the **Leave Organization** button appears in the **Danger Zone** section at the bottom of the General settings page alongside the **Delete Organization** option.
 
-**If you are not an admin**, the Leave Organization option appears as a standalone card outside the Danger Zone section.
+**If you are not an admin**, the **Leave Organization** option appears as a standalone card outside the Danger Zone section.


### PR DESCRIPTION
## Summary
- Adds a new "Leaving an Organization" section to `setup-and-administration/managing-your-organization.md`
- Describes where to find the Leave Organization button for both admin and non-admin users
- Notes that access is fully revoked after leaving and can be restored via a new invite

## Source
- trunk2 PR: https://github.com/trunk-io/trunk2/pull/3933

## Test plan
- [ ] Preview in GitBook

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUf5cB6KgikVtxwzPF86Dm)_