### PR TITLE
docs(flaky-tests): document monitor action type selection for failure rate and failure count monitors

### DIFF
--- a/flaky-tests/detection/failure-count-monitor.md
+++ b/flaky-tests/detection/failure-count-monitor.md
@@ -1,5 +1,5 @@
 ---
-description: Detect flaky or broken tests as soon as they accumulate a configured number of failures
+description: Detect and classify or label tests as soon as they accumulate a configured number of failures
 ---
 
 # Failure Count Monitor
@@ -18,14 +18,25 @@ Use the failure count monitor when you want immediate visibility into test failu
 
 If you need to detect patterns of intermittent failure over time (e.g., a test that fails 20% of the time), use a [failure rate monitor](failure-rate-monitor.md) instead. If you want to catch tests that fail and then pass on retry within a single commit, [pass-on-retry](pass-on-retry-monitor.md) handles that automatically.
 
+## Action Type
+
+When creating a failure count monitor, choose what action it takes when a test is flagged:
+
+- **Classify test status** — marks the test as flaky or broken. This is the default and integrates with quarantine workflows and status-based filtering.
+- **Apply labels** — tags matching tests with one or more labels when the monitor activates. Use this when you want to categorize tests automatically without changing their status. See [Automatic labeling from monitors](../management/test-labels.md#automatic-labeling-from-monitors) for details.
+
+The action type is set at creation and cannot be changed afterward. If you need to switch a monitor's action type, create a new monitor with the desired type and disable the old one.
+
 ## Detection Type
 
-Each failure count monitor has a **detection type** -- either **flaky** or **broken** -- which controls what status a test receives when the monitor flags it:
+Applies only to monitors with the **Classify test status** action type.
+
+Each classify-action failure count monitor has a **detection type** -- either **flaky** or **broken** -- which controls what status a test receives when the monitor flags it:
 
 - **Flaky monitors** are appropriate when failures on the monitored branch are likely non-deterministic. A test that fails once on `main` but passes on retry is probably flaky.
 - **Broken monitors** are appropriate when failures indicate a real regression. If a test fails on `main` and you expect it to keep failing until someone fixes it, broken is the right classification.
 
-The detection type is set at creation and cannot be changed afterward. If you need to switch a monitor's type, create a new monitor with the desired type and disable the old one.
+The detection type is set at creation and cannot be changed afterward. If you need to switch a monitor's detection type, create a new monitor with the desired type and disable the old one.
 
 ## How It Works
 
@@ -37,6 +48,7 @@ You configure a failure count monitor with:
 
 | Setting | Value |
 |---|---|
+| Action type | Classify test status |
 | Detection type | Broken |
 | Failure count | 1 |
 | Window | 30 minutes |
@@ -55,6 +67,14 @@ A developer merges a change that breaks `test_checkout`. Here is what happens:
 If another test, `test_signup`, also failed during that window, it would be flagged independently. Each test is evaluated on its own.
 
 ## Configuration
+
+### Action Type
+
+Choose **Classify test status** or **Apply labels**. See [Action Type](#action-type) above for details. This cannot be changed after the monitor is created.
+
+### Detection Type
+
+Appears only when the action type is **Classify test status**. Choose **Flaky** or **Broken**. This determines the status a test receives when the monitor flags it. See [Detection Type](#detection-type) above for guidance.
 
 ### Failure Count
 

--- a/flaky-tests/detection/failure-rate-monitor.md
+++ b/flaky-tests/detection/failure-rate-monitor.md
@@ -6,16 +6,27 @@ description: Detect flaky or broken tests based on failure rate over a configura
 
 The failure rate monitor detects tests based on failure rate over a rolling time window. Unlike pass-on-retry, which looks for a specific pattern on a single commit, the failure rate monitor identifies tests that fail too often over a period of time, even if no individual failure looks like a retry.
 
-You can create multiple failure rate monitors with different configurations. This is how you tailor detection to different branches, test volumes, sensitivity levels, and detection types.
+You can create multiple failure rate monitors with different configurations. This is how you tailor detection to different branches, test volumes, sensitivity levels, and action types.
+
+## Action Type
+
+When creating a failure rate monitor, choose what action it takes when a test is flagged:
+
+- **Classify test status** — marks the test as flaky or broken. This is the default and integrates with quarantine workflows and status-based filtering.
+- **Apply labels** — tags matching tests with one or more labels when the monitor activates. Use this when you want to categorize tests automatically without changing their status. See [Automatic labeling from monitors](../management/test-labels.md#automatic-labeling-from-monitors) for details.
+
+The action type is set at creation and cannot be changed afterward. If you need to switch a monitor's action type, create a new monitor with the desired type and disable the old one.
 
 ## Detection Type
 
-Each failure rate monitor has a **detection type** — either **flaky** or **broken** — which controls what status a test receives when the monitor flags it:
+Applies only to monitors with the **Classify test status** action type.
+
+Each classify-action failure rate monitor has a **detection type** — either **flaky** or **broken** — which controls what status a test receives when the monitor flags it:
 
 - **Flaky monitors** catch tests that fail intermittently (e.g., 20–50% failure rate). These are typically caused by timing issues, shared state, or non-deterministic behavior.
 - **Broken monitors** catch tests that fail consistently at a high rate (e.g., 80%+ failure rate). These usually indicate a real regression — something in the code or environment is genuinely broken and needs a fix.
 
-The detection type is set at creation and cannot be changed afterward. If you need to switch a monitor's type, create a new monitor with the desired type and disable the old one.
+The detection type is set at creation and cannot be changed afterward. If you need to switch a monitor's detection type, create a new monitor with the desired type and disable the old one.
 
 This distinction matters because the two problems call for different responses. Flaky tests might be quarantined while you investigate the root cause. Broken tests represent real failures that should be fixed, not hidden.
 
@@ -53,9 +64,13 @@ stale timeout, and branch scope. Capture it with realistic example values filled
 in (e.g., "Broken on main", Broken detection type, 80% activation, 60% resolution,
 6 hour window, 50 min sample, main branch). -->
 
+### Action Type
+
+Choose **Classify test status** or **Apply labels**. See [Action Type](#action-type) above for details. This cannot be changed after the monitor is created.
+
 ### Detection Type
 
-Choose **Flaky** or **Broken**. This determines the status a test receives when the monitor flags it. See [Detection Type](#detection-type) above for guidance on which to use.
+Appears only when the action type is **Classify test status**. Choose **Flaky** or **Broken**. This determines the status a test receives when the monitor flags it. See [Detection Type](#detection-type) above for guidance on which to use.
 
 ### Activation Threshold
 


### PR DESCRIPTION
## Summary

- Adds an **Action Type** section to both the Failure Rate Monitor and Failure Count Monitor pages explaining the two options: Classify test status vs. Apply labels
- Moves **Detection Type** (flaky/broken) into context as a setting that applies only to classify-action monitors
- Updates the configuration tables and subsections in both pages to reflect the new creation form flow
- Links to the Test Labels page for the apply-labels path

Shipped in v174 via trunk-io/trunk2#3945. Pairs with #651 which documents automatic labeling from the test-labels side.

## Test plan

- [ ] Verify Action Type section appears in correct location on both pages
- [ ] Verify Detection Type section is clearly scoped to classify-action monitors
- [ ] Check links to test-labels.md#automatic-labeling-from-monitors resolve

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDkQx9XA8YKBZpdMi6WXy4)_