### PR TITLE
[feature not live] docs(merge-queue): document configurable label commands for enqueueing

### DIFF
--- a/merge-queue/using-the-queue/reference.md
+++ b/merge-queue/using-the-queue/reference.md
@@ -20,6 +20,8 @@ trunk login
 trunk merge <pr-number>
 ```
 
+* Applying the configured enqueueing label to a pull request (when label commands are enabled — see [Label Commands](#label-commands) below).
+
 Admins can also use [`/trunk merge --force`](force-merge.md) to push a PR through the queue when branch protection isn't satisfied.
 
 We offer similar commands for cancellation.
@@ -35,6 +37,8 @@ We offer similar commands for cancellation.
 trunk login
 trunk merge cancel <pr-number>
 ```
+
+* Removing the configured enqueueing label from a pull request (when label commands are enabled).
 
 ## Custom merge commit titles
 
@@ -63,6 +67,29 @@ merge-commit-title: feat(auth): add OAuth2 login flow [PROJ-123]
 The `merge-commit-title:` directive only customizes the merge commit **title**. The commit body follows the usual behavior for your configured [merge method](../administration/advanced-settings.md#merge-method).
 
 The directive applies to the **Squash** and **Merge Commit** merge methods. It has no effect when using **Rebase**, since rebase replays the original commits onto the target branch and does not produce a separate merge commit.
+{% endhint %}
+
+## Label Commands
+
+Label Commands let you enqueue and cancel PRs in the Merge Queue by applying or removing a GitHub label, without leaving a comment or using the CLI.
+
+### Enabling Label Commands
+
+Label Commands are configured per merge queue instance in **Merge Queue Settings** > **Label Commands**. Only organization admins can change this setting.
+
+When Label Commands are enabled, you can configure the enqueueing label name. The default label is `trunk-merge-queue-submit`.
+
+### How it works
+
+| Action | Effect |
+| ------ | ------ |
+| Apply the enqueueing label to a PR | Submits the PR to the Merge Queue |
+| Remove the enqueueing label from a PR | Cancels the PR from the queue |
+
+The label must already exist in your GitHub repository. Trunk does not create the label automatically.
+
+{% hint style="info" %}
+Label Commands work alongside comment commands and the Trunk web app. You can use any combination of submission methods; they all target the same queue.
 {% endhint %}
 
 ## Pull request processing


### PR DESCRIPTION
## Summary
- Documents the new Label Commands setting in Merge Queue Settings
- Explains how to enable label-based enqueue/cancel and configure the label name
- Adds a new "Label Commands" section to the Submit and Cancel PR reference page

## Source
- trunk2 PR: https://github.com/trunk-io/trunk2/pull/3956
- Linear: https://linear.app/trunk/issue/TRUNK-18126

## Test plan
- [ ] Preview in GitBook
- [ ] Verify label table renders correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGKmXtzS58oueH6tFXKB9A)_