### PR TITLE
docs(flaky-tests): clarify that monitor detection type is editable after creation

### DIFF
--- a/flaky-tests/detection/failure-count-monitor.md
+++ b/flaky-tests/detection/failure-count-monitor.md
@@ -79,7 +79,7 @@ Branch patterns work the same way as [failure rate monitor branch patterns](fail
 
 ### Action
 
-What happens when the monitor activates on a test. You pick the action at creation and can switch it at any time.
+What happens when the monitor activates on a test. You pick the action at creation and can change both the action type and the detection type (Flaky or Broken) at any time. If the monitor is active on any tests when you switch the detection type, those tests are re-evaluated immediately with the new classification.
 
 #### Classify test status (default)
 

--- a/flaky-tests/detection/failure-rate-monitor.md
+++ b/flaky-tests/detection/failure-rate-monitor.md
@@ -150,7 +150,7 @@ each pattern. -->
 
 ### Action
 
-What happens when the monitor activates on a test. You pick the action at creation and can switch it at any time.
+What happens when the monitor activates on a test. You pick the action at creation and can change both the action type and the detection type (Flaky or Broken) at any time. If the monitor is active on any tests when you switch the detection type, those tests are re-evaluated immediately with the new classification.
 
 #### Classify test status (default)
 


### PR DESCRIPTION
## Summary
- Clarifies that both the action type (Classify / Apply labels) and the detection type (Flaky or Broken) can be changed after a monitor is created
- Adds a note that tests actively flagged by the monitor are re-evaluated immediately when the detection type is updated
- Applies to Failure Count Monitor and Failure Rate Monitor docs

## Source
- trunk2 PR: https://github.com/trunk-io/trunk2/pull/3951

## Test plan
- [ ] Preview in GitBook

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qfnr8Nuy1sHvLHRCn1Cmg4)_