### PR TITLE
docs(flaky-tests): Linear field defaults, Link Ticket modal, settings form

### DIFF
--- a/flaky-tests/management/ticketing/linear-integration.md
+++ b/flaky-tests/management/ticketing/linear-integration.md
@@ -8,7 +8,7 @@ description: >-
 
 When Trunk Flaky Tests [detects a flaky test](../../detection/README.md), you can create an automatically generated Linear ticket for your team to pick up and fix the test.
 
-Webhook payloads will also contain ticket information when a Jira ticket is created with the integration or when [existing tickets are linked](linear-integration.md#link-existing-tickets-to-tests).
+Webhook payloads will also contain ticket information when a ticket is created with the integration or when [existing tickets are linked](linear-integration.md#link-an-existing-ticket).
 
 ### Connecting to Linear
 
@@ -21,7 +21,7 @@ To connect a Linear project:
 3. Add a [Linear API key](linear-integration.md#api-token-permissions)
 4. Select a Team and **Connect to Linear**.
 
-After connecting to Linear, you can specify a default project and a default assignee for new tickets.
+After connecting, you can configure field defaults that pre-populate every new ticket created from the dashboard.
 
 #### API Key permissions
 
@@ -32,9 +32,23 @@ The following project permissions must be granted to your Linear API key so Trun
 
 Selecting _Full Access_ will also grant the required permissions.
 
+### Field defaults
+
+Once a team is selected, the configuration form shows the following optional fields — all scoped to that team:
+
+| Field | Description |
+|---|---|
+| **Priority** | Default priority (Urgent, High, Medium, Low) |
+| **Labels** | One or more team or workspace labels |
+| **Estimate** | Story point estimate, using the team's configured estimate type (fibonacci, t-shirt, etc.) |
+| **Project** | Default Linear project for new tickets |
+| **Assignee** | Default assignee, from the team's members |
+
+Changing the team clears all field defaults and reloads the available options for the new team.
+
 ### Create a new ticket
 
-You can create a new ticket for any test listed in Flaky Tests.&#x20;
+You can create a new ticket for any test listed in Flaky Tests.
 
 There are 2 ways to create a new ticket in the Flaky Tests dashboard:
 
@@ -42,18 +56,24 @@ There are 2 ways to create a new ticket in the Flaky Tests dashboard:
 
 <figure><picture><source srcset="../../../.gitbook/assets/create-ticket-button-dark.png" media="(prefers-color-scheme: dark)"><img src="../../../.gitbook/assets/create-ticket-button-light.png" alt=""></picture><figcaption></figcaption></figure>
 
-* Use the Create ticket button in the top left corner of the [test case details](../../dashboard.md#test-case-details) page.
+* Use the **Create ticket** button in the top left corner of the [test case details](../../dashboard.md#test-case-details) page.
 
-Before you create the ticket, you get a preview of the title and description.
+Before you create the ticket, you get a preview of the title and description. Any field defaults configured in settings will pre-populate in the creation modal, and you can adjust them before submitting.
 
 <figure><picture><source srcset="../../../.gitbook/assets/jira-ticket-creation-dark.png" media="(prefers-color-scheme: dark)"><img src="../../../.gitbook/assets/jira-ticket-creation-light.png" alt=""></picture><figcaption></figcaption></figure>
 
-#### Create with Linear
+If you are connected to Linear, click the **Create Linear Ticket** button at the end of the modal to create the ticket with the configured team, field defaults, and assignees.
 
-If you are connected to Linear, you can click the **Create Linear Ticket** button at the end of the modal to automatically create a ticket with the configured team and assignees.
+You can use [Flaky Tests webhooks](../../webhooks/linear-integration.md) to automate ticket creation, or if you need more control over how tickets are created in Linear. The ticketing integration is not required when using webhooks.
 
-Note: You can use [Flaky Tests webhooks](../../webhooks/linear-integration.md) to automate ticket creation, or if you need more control over how tickets are created in Linear. This integration is not required when using webhooks.
+### Link an existing ticket
 
-#### Link existing tickets to tests
+If you already have a Linear ticket for a flaky test, you can link it directly from the test case details page without creating a new one.
 
-If you already have a ticket in Linear that you want to link to a test in the dashboard, you can use the [Link Ticket to Test Case API](../../reference/api-reference.md#post-flaky-tests-link-ticket-to-test-case).
+1. Open the test case details page.
+2. Click **Link Ticket** in the top left corner.
+3. Paste the Linear ticket URL or ID and click **Link**.
+
+Trunk imports the ticket's title, status, and assignee and displays them on the test details page. Linked tickets also appear in webhook payloads.
+
+You can also link tickets programmatically using the [Link Ticket to Test Case API](../../reference/api-reference.md#post-flaky-tests-link-ticket-to-test-case).


### PR DESCRIPTION
## Summary
- Documents new Linear ticketing field defaults (Priority, Labels, Estimate, Project, Assignee) scoped per team
- Documents the new Link Ticket UI modal on the test case details page (previously API-only)
- Updates settings section to reflect consolidated Configuration form

## Source
- trunk2 PR: https://github.com/trunk-io/trunk2/pull/3968

## Test plan
- [ ] Preview in GitBook

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpJQB3N7YLLSNqR5ZMyeDM)_